### PR TITLE
BaseX model computed properties fail and cause unnecessary datastore writes

### DIFF
--- a/main/modelx.py
+++ b/main/modelx.py
@@ -37,7 +37,7 @@ class ConfigX(object):
 
 
 class UserX(object):
-  @ndb.ComputedProperty
+  @property
   def avatar_url(self):
     return 'http://www.gravatar.com/avatar/%s?d=identicon&r=x' % (
         md5.new(self.email or self.name).hexdigest().lower()


### PR DESCRIPTION
Hi,

there are several computed properties in main/modelx.py BaseX like
- `created_ago`
- `modified_ago`
- `created_utc`
- `modified_utc`

Computed properties ([1](https://developers.google.com/appengine/docs/python/ndb/properties#computed)) are both computed whenever read and saved in the datastore for the purpose of indexing. The idea is that you can still query on the field. This causes at least 3 additional writes per object being written (1 for the data itself, 2 for index asc and desc).

Aside from causing additional writes there seems to be a problem: all four are depending on self.modified and self.created which are `DateTimeProperties` ([2](https://developers.google.com/appengine/docs/python/ndb/properties#Date_and_Time)).
The values of `auto_now` and `auto_now_add` are only set when the model is written. I experienced non deterministic `None` values of these in the Datastore.

I see two other problems here: 
1. `created_ago` and `modified_ago` just should never be saved in the datastore, as ordering by these two just doesn't make any sense.
2. `created_utc` and `modified_utc` imply that the normal times are saved in localtime. They're not, appengine uses UTC.

I suggest transforming all these into ordinary properties. (Pull request coming)
