### PR TITLE
Fixed faulty signin page optimization

### DIFF
--- a/main/static/src/style/signin.less
+++ b/main/static/src/style/signin.less
@@ -1,14 +1,14 @@
-.btn-social {
+.btn-social(@bgcolor: @gray) {
   @height: @line-height-computed + @padding-base-vertical * 2;
   position: relative;
   padding-left: @height + @padding-base-horizontal;
   padding-right: @padding-base-horizontal;
-  background-color: @gray;
+  background-color: @bgcolor;
   text-align: left;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  .button-variant(white, @gray, rgba(0, 0, 0, 0.2));
+  .button-variant(white, @bgcolor, rgba(0, 0, 0, 0.2));
   :first-child {
     position: absolute;
     left: 0;
@@ -50,11 +50,6 @@
       font-size: 1.2em;
     }
   }
-}
-
-.btn-social(@color) {
-  background-color: @color;
-  .button-variant(white, @color, rgba(0, 0, 0, 0.2));
 }
 
 

--- a/main/templates/signin.html
+++ b/main/templates/signin.html
@@ -12,20 +12,20 @@
 
   <div class="row">
     <div class="col-lg-4 col-lg-offset-4 col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3">
-      <a class="btn btn-block btn-lg btn-social btn-google" href="{{google_signin_url}}" rel="nofollow">
+      <a class="btn btn-block btn-lg btn-google" href="{{google_signin_url}}" rel="nofollow">
         <i class="fa fa-google-plus"></i>
         Sign in with Google
       </a>
 
       # if config.CONFIG_DB.facebook_app_id and config.CONFIG_DB.facebook_app_secret
-        <a class="btn btn-block btn-lg btn-social btn-facebook" href="{{facebook_signin_url}}" rel="nofollow">
+        <a class="btn btn-block btn-lg btn-facebook" href="{{facebook_signin_url}}" rel="nofollow">
           <i class="fa fa-facebook"></i>
           Sign in with Facebook
         </a>
       # endif
 
       # if config.CONFIG_DB.twitter_consumer_key and config.CONFIG_DB.twitter_consumer_secret
-        <a class="btn btn-block btn-lg btn-social btn-twitter" href="{{twitter_signin_url}}" rel="nofollow">
+        <a class="btn btn-block btn-lg btn-twitter" href="{{twitter_signin_url}}" rel="nofollow">
           <i class="fa fa-twitter"></i>
           Sign in with Twitter
         </a>


### PR DESCRIPTION
After 97b1c4b4d873aac19b9ff00b61b14d8822417b74 and 0d503f33de7a4536fc3d98012262f48003dc256a in Safari 7.0 signing page looks like this
![screen shot 2013-10-30 at 2 07 58 pm](https://f.cloud.github.com/assets/47926/1435953/c747ddba-414b-11e3-8734-ac560838abc7.png)
