### PR TITLE
Generalisation: using "Avatar of" instead of "Gravatar photo of"

### DIFF
--- a/main/templates/profile.html
+++ b/main/templates/profile.html
@@ -24,7 +24,7 @@
         <div class="form-group">
           <label class="control-label">Avatar</label>
           <div>
-            <img class="img-thumbnail" src="{{user_db.avatar_url_size(170)}}" alt="Gravatar photo of {{user_db.name}}">
+            <img class="img-thumbnail" src="{{user_db.avatar_url_size(170)}}" alt="Avatar of {{user_db.name}}">
           </div>
           <p class="help-block">
             Change on


### PR DESCRIPTION
Using "Avatar of" instead of "Gravatar photo of" so that someone may change it to another provider or a custom solution to get such avatars (and who says it needs to be a photo?)
