### PR TITLE
Fix for issue #40 ensuring there are no dupes in list of scripts

### DIFF
--- a/run.py
+++ b/run.py
@@ -235,8 +235,6 @@ def update_missing_args():
 
 
 def uniq(seq):
-  '''Returns list of unique elements in seq (= removes duplicates),
-  while preserving order of elements as provided in seq.'''
   seen = set()
   return [e for e in seq if e not in seen and not seen.add(e)]
 


### PR DESCRIPTION
Seems like comment in commit didn't go thru properly; should have read: Fix for issue #40 adding `uniq()` to `run.py` to ensure there are no dupes in list of scripts
