### PR TITLE
Updating to UglifyJS2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "coffee-script": "~1",
     "less": "~1",
-    "uglify-js": "~1"
+    "uglify-js": "~2"
   },
   "devDependencies": {
     "grunt": "0.4.x",

--- a/run.py
+++ b/run.py
@@ -291,7 +291,7 @@ if args.minify:
         continue
       script_file = os.path.join(dir_static, script)
       merge_files(script_file, pretty_js)
-    os_execute(file_uglifyjs, '-nc', pretty_js, ugly_js)
+    os_execute(file_uglifyjs, pretty_js, '-cm', ugly_js)
     os.remove(pretty_js)
   print_out('DONE')
 


### PR DESCRIPTION
Updating to v2.x series of UglifyJS2 (see https://github.com/mishoo/UglifyJS2) which also requires some changes in our `run.py` due to a slightly different commandline for UglifyJS2 (see http://lisperator.net/blog/should-you-switch-to-uglifyjs2/). This update generates a few WARN messages when using `./run.py -m` (originating from UglifyJS2).

Note that you may need to wipe your current `./node_modules/` folder, to ensure that `npm` collects the latest version; otherwise, you may see some error regarding a "require" of "../tools/node" (or something like that).
