### PR TITLE
Explicit mime type for .ttf font files

### DIFF
--- a/main/app.yaml
+++ b/main/app.yaml
@@ -26,9 +26,9 @@ handlers:
 # to enjoy gzip encoding/compression from GAE hosting.
 # Order is important: this must precede "/p/" static_dir
 # See: https://github.com/gae-init/gae-init/issues/53
-- url: /p/font/(.*\.ttf)
-  static_files: static/font/\1
-  upload: static/font/(.*\.ttf)
+- url: /p/(.*\.ttf)
+  static_files: static/\1
+  upload: static/(.*\.ttf)
   mime_type: font/ttf
   expiration: 1000d
 


### PR DESCRIPTION
Fix for https://github.com/gae-init/gae-init/issues/53 _"Could not guess mimetype warnings for .ttf files"_ including comment in the `app.yaml` that order is important: the `url: /p/font/(.*\.ttf)` handler must precede the `url: /p/` handler so that Google App Engine can provide gzip encoding/compression on these .ttf font files.

Note that changing order doesn't break anything, it just doesn't get you the compression and bandwidth/time benefits, therefore a "must" (and not a "shall").
