### PR TITLE
Updated threadsafe setting (to fit Google documentation)

### DIFF
--- a/main/app.yaml
+++ b/main/app.yaml
@@ -2,7 +2,7 @@ application: gae-init
 version: 1
 runtime: python27
 api_version: 1
-threadsafe: yes
+threadsafe: true
 
 builtins:
 - remote_api: on


### PR DESCRIPTION
Google App Engine documentation is pretty clear that `threadsafe: true` (for GAE to send requests concurrently); see https://developers.google.com/appengine/docs/python/config/appconfig#threadsafe
