### PR TITLE
Make announcement_html a TextProperty to allow 500+ characters

### DIFF
--- a/main/model.py
+++ b/main/model.py
@@ -27,7 +27,7 @@ class Base(ndb.Model, modelx.BaseX):
 
 class Config(Base, modelx.ConfigX):
   analytics_id = ndb.StringProperty(default='')
-  announcement_html = ndb.StringProperty(default='')
+  announcement_html = ndb.TextProperty(default='')
   announcement_type = ndb.StringProperty(default='info', choices=[
       'info', 'warning', 'success', 'danger',
     ])


### PR DESCRIPTION
Though 500 or less characters could be sufficient for most announcements, it feels better to have a little more space; considering the fact that markup and such will need to go into it as well.
