### PR TITLE
No need for explicit index on User properties

### DIFF
--- a/main/model.py
+++ b/main/model.py
@@ -16,6 +16,7 @@ class Base(ndb.Model, modelx.BaseX):
   created = ndb.DateTimeProperty(auto_now_add=True)
   modified = ndb.DateTimeProperty(auto_now=True)
   version = ndb.IntegerProperty(default=TIMESTAMP)
+
   _PROPERTIES = {
       'key',
       'id',
@@ -54,11 +55,10 @@ class Config(Base, modelx.ConfigX):
 
 
 class User(Base, modelx.UserX):
-  name = ndb.StringProperty(indexed=True, required=True)
-  username = ndb.StringProperty(indexed=True, required=True)
-  email = ndb.StringProperty(indexed=True, default='')
-  auth_ids = ndb.StringProperty(indexed=True, repeated=True)
-
+  name = ndb.StringProperty(required=True)
+  username = ndb.StringProperty(required=True)
+  email = ndb.StringProperty(default='')
+  auth_ids = ndb.StringProperty(repeated=True)
   active = ndb.BooleanProperty(default=True)
   admin = ndb.BooleanProperty(default=False)
 


### PR DESCRIPTION
As suggested in https://github.com/gae-init/gae-init-babel/pull/24 - removing explicit `indexed=True` for most User properties of the `StringProperty` type; since they are candidate for indexing by default anyway (see https://developers.google.com/appengine/docs/python/ndb/properties#options)
