### PR TITLE
Add links macro

### DIFF
--- a/main/templates/admin/config_update.html
+++ b/main/templates/admin/config_update.html
@@ -1,6 +1,6 @@
 # extends 'base.html'
 # import 'macro/forms.html' as forms
-# import 'macro/links.html' as links
+# import 'macro/utils.html' as utils
 
 # block content
   <div class="page-header">
@@ -12,10 +12,10 @@
       <legend>Information</legend>
       <ul>
         <li>For most of the settings you will have to
-        {{(links.blank_link(instances_url, 'restart') if instances_url else 'restart')}}
-        the {{links.blank_link('https://developers.google.com/appengine/docs/adminconsole/instances', 'instances')}}</li>
-        <li>Site URL for {{links.blank_link('https://developers.facebook.com/apps' 'Facebook application')}}: <em>{{request.host_url[:-1]}}</em></li>
-        <li>Callback URL for {{links.blank_link('https://dev.twitter.com/apps', 'Twitter application')}}: <em>{{'%s%s' % (request.host_url[:-1], url_for('twitter_authorized'))}}</em></li>
+        {{(utils.blank_link(instances_url, 'restart') if instances_url else 'restart')}}
+        the {{utils.blank_link('https://developers.google.com/appengine/docs/adminconsole/instances', 'instances')}}</li>
+        <li>Site URL for {{utils.blank_link('https://developers.facebook.com/apps' 'Facebook application')}}: <em>{{request.host_url[:-1]}}</em></li>
+        <li>Callback URL for {{utils.blank_link('https://dev.twitter.com/apps', 'Twitter application')}}: <em>{{'%s%s' % (request.host_url[:-1], url_for('twitter_authorized'))}}</em></li>
       </ul>
     </div>
     <div class="col-md-8 col-md-pull-4">

--- a/main/templates/macro/links.html
+++ b/main/templates/macro/links.html
@@ -1,3 +1,0 @@
-# macro blank_link(url, txt)
-  <a href="{{url}}" target="_blank">{{txt}}</a>
-# endmacro

--- a/main/templates/macro/utils.html
+++ b/main/templates/macro/utils.html
@@ -24,6 +24,11 @@
 # endmacro
 
 
+# macro blank_link(url, txt)
+  <a href="{{url}}" target="_blank">{{txt}}</a>
+# endmacro
+
+
 # macro next_link(more_url, caption='Next Page')
   # if more_url
     <ul class="pager">


### PR DESCRIPTION
Adding a macro for `_blank` links, named `utils.blank_link(url, txt)` and in this PR currently only used in `config_update.html` to show how this would work.

The main advantage will show in `gae-init-babel`, where it would allow using:

```
<li>{{_('For most of the settings you will have to {restart} the {instances}').format(
  restart=(utils.blank_link(instances_url, _('restart')) if instances_url else _('restart')),
  instances=utils.blank_link('https://developers.google.com/appengine/docs/adminconsole/instances', _('instances')),
)}}</li>
```

So that translators can deal with "For most of the settings you will have to {restart} the {instances}" part in ways that are important in their language; which could include a different order of "restart" and "instances" in the translated sentence. Which, in this particular case, would sometimes be links and sometimes plain text.

I'm aware that translating Administrator pages is controversial, the above is from my own project based on `gae-init-babel` which does. However, this proposal doesn't do that... it just proposes to have a macro in the `gae-init` core to make links with a `_blank` target. And the explanation provided above is to address (appropriate) "why bother?" questions.
