### PR TITLE
Moved caption default into body of macro

### DIFF
--- a/main/templates/macro/utils.html
+++ b/main/templates/macro/utils.html
@@ -24,7 +24,7 @@
 # endmacro
 
 
-# macro next_link(more_url, caption)
+# macro next_link(more_url, caption=None)
   # if more_url
     <ul class="pager">
       <li><a href="{{more_url}}" rel="nofollow">{{caption if caption else 'Next Page'}}</a></li>


### PR DESCRIPTION
Found in `gae-init-babel` (yes, downstream) that trying to use a `caption=_('Next Page')` default parameter on the `next_link` macro doesn't work: it throws a `NameError: global name 'l__' is not defined`

Probably due to something in Jinja2 parsing the macro definition.

Nevertheless, that is why I propose to remove the parameter default on the macro definition and use an inline if-else in the macro body instead. That will allow `gae-init-babel` and derived projects to translate it.
