### PR TITLE
Adding html_element utility macro

### DIFF
--- a/main/templates/macro/utils.html
+++ b/main/templates/macro/utils.html
@@ -63,11 +63,11 @@
 
 # macro html_element(name, content)
   <{{name}}
-    # for arg in kwargs
+    #- for arg in kwargs
       {{arg}}="{{kwargs[arg]}}"
-    # endfor
+    #- endfor
   >
-  # if content
+  #- if content
     {{content}}</{{name}}>
-  # endif
+  #- endif
 # endmacro


### PR DESCRIPTION
Adding html_element utility macro in `utils.html` to create links or any other html element like this:

```
{{utils.html_element('a', 'google', href='http://google.com')}}
{{utils.html_element('a', 'google', href='http://google.com', target='_blank', class='external')}}
{{utils.html_element('img', src='http://i.imgur.com/qNIy7lH.jpg')}}
{{utils.html_element('br')}}
```

Based on @lipis macro suggested in #74, the proposed implementation is less _spacy_ in that it removes/avoids whitespace in the output html.
