### PR TITLE
Adding new html_element utility macro

### DIFF
--- a/main/templates/macro/utils.html
+++ b/main/templates/macro/utils.html
@@ -59,3 +59,15 @@
     {{auth_icon(auth_id)}}
   # endfor
 # endmacro
+
+
+# macro html_element(name, content)
+  <{{name}}
+    #- for arg in kwargs
+      {{arg}}="{{kwargs[arg]}}"
+    #- endfor
+  >
+  #- if content
+    {{content}}</{{name}}>
+  #- endif
+# endmacro


### PR DESCRIPTION
Adding new html_element utility macro in `utils.html` to create links or any other html element like this:

```
{{utils.html_element('a', 'google', href='http://google.com')}}
{{utils.html_element('a', 'google', href='http://google.com', target='_blank', class='external')}}
{{utils.html_element('img', src='http://i.imgur.com/qNIy7lH.jpg')}}
{{utils.html_element('br')}}
```

Based on @lipis macro suggested in #74, see also #80 for some background on the implementation.
