### PR TITLE
Setting page help block style

### DIFF
--- a/main/templates/admin/config_update.html
+++ b/main/templates/admin/config_update.html
@@ -4,7 +4,7 @@
 # block content
   <div class="page-header">
     <h1>{{title}}</h1>
-    <p class="text-muted">
+    <p class="help-block">
       For most of the settings you will
       # if instances_url
         <a href="{{instances_url}}" target="_blank">have to restart</a>


### PR DESCRIPTION
Instead of `text-muted` setting the style of the `config_update.html` page help block to `help-block`; similar to how the help blocks for the OAuth panels are styled (as seen inside the `oauth_fields` macro in `forms.html`).
