### PR TITLE
Formatting title differently in base template

### DIFF
--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>
       # block title
-        {{(title + ' |') if title}}
+        {{title + ' |' if title}}
       # endblock
       {{config.CONFIG_DB.brand_name}}
     </title>


### PR DESCRIPTION
Addressing the translation issue with lazy `title` parameters in `gae-init-babel` (see https://github.com/gae-init/gae-init-babel/issues/27); this is simply a different way of formatting (part of) the page title in the `base.html` template.
