### PR TITLE
Removed uuid doc string already in gae-init-docs

### DIFF
--- a/main/util.py
+++ b/main/util.py
@@ -182,8 +182,6 @@ def generate_more_url(more_cursor, base_url=None, cursor_name='cursor'):
 
 
 def uuid():
-  ''' Generates universal unique identifier
-  '''
   return uuid4().hex
 
 


### PR DESCRIPTION
Removed doc string for `util.uuid()` already documented at http://docs.gae-init.appspot.com/reference/#util.uuid (re: https://github.com/gae-init/gae-init/issues/88)
