### PR TITLE
Fix issue with minor version of CURRENT_VERSION_ID

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -19,8 +19,8 @@ try:
   CURRENT_VERSION_ID = os.environ.get('CURRENT_VERSION_ID')
   CURRENT_VERSION_NAME = CURRENT_VERSION_ID.split('.')[0]
   if PRODUCTION:
-    ts = long(CURRENT_VERSION_ID.split('.')[1]) >> 28
-    CURRENT_VERSION_DATE = datetime.fromtimestamp(ts)
+    CURRENT_VERSION_DATE = datetime.fromtimestamp(
+      long(CURRENT_VERSION_ID.split('.')[1]) >> 28)
   else:
     CURRENT_VERSION_DATE = datetime.utcnow()
   APPLICATION_ID = app_identity.get_application_id()


### PR DESCRIPTION
Fix issue with minor version of CURRENT_VERSION_ID as described in https://github.com/gae-init/gae-init/issues/90 that caused exceptions (note: sometimes, not always... due to randomness of the specific value assigned to it on the development server) when converting into CURRENT_VERSION_DATE.

This PR suggests to drop the CURRENT_VERSION_TIMESTAMP as this doesn't seem to be used anywhere else in code or templates.
