### PR TITLE
Allow disabled checkbox field

### DIFF
--- a/main/templates/macro/forms.html
+++ b/main/templates/macro/forms.html
@@ -69,7 +69,7 @@
 
 # macro checkbox_field(field)
   <div class="checkbox {{'has-error' if field.errors}}">
-    <label>
+    <label class="{{'text_muted' if 'disabled' in kwargs}}">
       {{field(**kwargs)}} {{field.label.text}}
     </label>
     {{field_errors(field)}}

--- a/main/templates/user/user_update.html
+++ b/main/templates/user/user_update.html
@@ -24,6 +24,9 @@
         # if current_user.id != user_db.key.id()
           {{forms.checkbox_field(form.admin)}}
           {{forms.checkbox_field(form.active)}}
+        # else
+          {{forms.checkbox_field(form.admin, disabled=True, checked=user_db.admin)}}
+          {{forms.checkbox_field(form.active, disabled=True, checked=user_db.active)}}
         # endif
       </div>
       <div class="col-md-2 col-sm-6">


### PR DESCRIPTION
This PR replaces #96 _"Show disabled Admin and Active fields"_ with a more generic approach, allowing disabled / read-only checkbox fields to be used on forms. For example to show the Admin and Active fields when editing your own user details as an administrator (that is: via the User List, which is different from Profile Settings).
