### PR TITLE
Clean up argument explanation

### DIFF
--- a/run.py
+++ b/run.py
@@ -23,7 +23,7 @@ PARSER.add_argument(
   )
 PARSER.add_argument(
     '-c', '--clean', dest='clean', action='store_true',
-    help='''recompiles files when running the development web server''',
+    help='recompiles files when running the development web server',
   )
 PARSER.add_argument(
     '-C', '--clean-all', dest='clean_all', action='store_true',


### PR DESCRIPTION
No need to explain that `-c` / `--clean` argument is obsolete when `-s` is used. If any explanation is needed that this happens with `-s`, then it should be explained there instead.
