### PR TITLE
Remove temp folder on flush

### DIFF
--- a/run.py
+++ b/run.py
@@ -328,6 +328,7 @@ def run_watch():
 def run_flush():
   remove_dir(DIR_STORAGE)
   print_out('STORAGE CLEARED')
+  remove_dir(DIR_TEMP)
 
 
 def run_start():


### PR DESCRIPTION
BEWARE: Testing this PR will clear your local datastore and temp folder, you've been warned!

Remove `temp` folder on flush, using for example `./run.py -f` to clear the locale datastore.
