### PR TITLE
Handle sub-folders in bower exportOverride

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -20,6 +20,8 @@ module.exports = (grunt)->
           layout: (type, component) ->
             if type is 'fonts'
               path.join '../../vendor-fonts'
+            else if type.search(/{}/) > -1
+              path.join type.replace(/{}/, component)
             else
               path.join type, component
 


### PR DESCRIPTION
Modified the `grunt bower` task such that sub-folders can be handled when specified in the `exportOverride` using curly brackets, like the `"js/{}/lang"` in this `bower.json` snippet:

```
...
    "momentjs": {
      "js": "moment.js",
      "js/{}/lang": "lang/*.js"
    },
...
```

Which would fill `main/static/src/vendor/js/momentjs/lang/` with the locale specific .js scripts.

The PR currently doesn't provide an example of the usage, but `gae-init-babel` could use the above example (with some other minor changes); just to make the intermediate structure easier to read. It does however offer derived projects a way to maintain/select certain sub-folder structures if needed.
