### PR TITLE
Bower directory support and better cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ bower_components
 main/index.yaml
 main/lib.zip
 main/static/dst
+main/static/ext
 main/static/min
-main/static/src/vendor
-main/static/vendor-fonts
 node_modules
 temp/

--- a/.hgignore
+++ b/.hgignore
@@ -9,8 +9,7 @@ bower_components
 main/index.yaml
 main/lib.zip
 main/static/dst
+main/static/ext
 main/static/min
-main/static/src/vendor
-main/static/vendor-fonts
 node_modules
 temp/

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,5 +1,6 @@
-module.exports = (grunt)->
-  path = require('path')
+module.exports = (grunt) ->
+  path = require 'path'
+
   grunt.initConfig
     watch:
       style:
@@ -15,14 +16,18 @@ module.exports = (grunt)->
     bower:
       install:
         options:
-          targetDir: 'main/static/src/vendor'
-          cleanTargetDir: true
+          targetDir: 'main/static/ext'
           layout: (type, component) ->
-            if type is 'fonts'
-              path.join '../../vendor-fonts'
+            if type.search('/') > -1
+              path.join type.replace '/', "/#{component}/"
             else
               path.join type, component
 
-    grunt.loadNpmTasks('grunt-contrib-watch')
-    grunt.registerTask('default', ['watch'])
-    grunt.loadNpmTasks('grunt-bower-task')
+    clean:
+      ext: 'main/static/ext'
+
+    grunt.loadNpmTasks 'grunt-bower-task'
+    grunt.loadNpmTasks 'grunt-contrib-clean'
+    grunt.loadNpmTasks 'grunt-contrib-watch'
+    grunt.registerTask 'default', ['watch']
+    grunt.registerTask 'ext', ['clean:ext', 'bower']

--- a/bower.json
+++ b/bower.json
@@ -1,31 +1,31 @@
 {
   "name": "gae-init",
   "dependencies": {
-    "jquery": "~2",
     "bootstrap": "~3",
-    "nprogress": "https://github.com/lipis/nprogress.git#master",
+    "font-awesome": "~4",
+    "jquery": "~2",
     "momentjs": "~2",
-    "font-awesome": "~4"
+    "nprogress": "https://github.com/lipis/nprogress.git#master"
   },
   "exportsOverride": {
-    "jquery": {
-      "js": "dist/jquery.js"
-    },
     "bootstrap": {
       "js": "js/*.js",
       "less": "less/*.less",
-      "fonts": "fonts/*"
+      "font": "fonts/*"
     },
-    "nprogress": {
-      "js": "*.js",
-      "less": "*.less"
+    "font-awesome": {
+      "less": "less/*.less",
+      "font": "fonts/*"
+    },
+    "jquery": {
+      "js": "dist/jquery.js"
     },
     "momentjs": {
       "js": "*.js"
     },
-    "font-awesome": {
-      "less": "less/*.less",
-      "fonts": "fonts/*"
+    "nprogress": {
+      "js": "*.js",
+      "less": "*.less"
     }
   }
 }

--- a/main/app.yaml
+++ b/main/app.yaml
@@ -30,17 +30,21 @@ handlers:
   script: main.app
 
 skip_files:
+- ^(.*/)?#.*#
+- ^(.*/)?.*/RCS/.*
+- ^(.*/)?.*\.bak$
+- ^(.*/)?.*\.py[co]
+- ^(.*/)?.*~
+- ^(.*/)?Icon\r
+- ^(.*/)?\..*
 - ^(.*/)?app\.yaml
 - ^(.*/)?app\.yml
 - ^(.*/)?index\.yaml
 - ^(.*/)?index\.yml
-- ^(.*/)?#.*#
-- ^(.*/)?.*~
-- ^(.*/)?.*\.py[co]
-- ^(.*/)?.*/RCS/.*
-- ^(.*/)?\..*
-- ^(.*/)?.*\.bak$
-- ^(.*/)?Icon\r
 - ^lib/.*
-- ^static/src/.*
 - ^static/dst/.*
+- ^static/ext/coffee/.*
+- ^static/ext/css/.*
+- ^static/ext/js/.*
+- ^static/ext/less/.*
+- ^static/src/.*

--- a/main/config.py
+++ b/main/config.py
@@ -40,15 +40,15 @@ SCRIPTS_MODULES = [
 
 SCRIPTS = {
     'libs': [
-        'src/vendor/js/jquery/jquery.js',
-        'src/vendor/js/momentjs/moment.js',
-        'src/vendor/js/nprogress/nprogress.js',
-        'src/vendor/js/bootstrap/alert.js',
-        'src/vendor/js/bootstrap/button.js',
-        'src/vendor/js/bootstrap/transition.js',
-        'src/vendor/js/bootstrap/collapse.js',
-        'src/vendor/js/bootstrap/dropdown.js',
-        'src/vendor/js/bootstrap/tooltip.js',
+        'ext/js/jquery/jquery.js',
+        'ext/js/momentjs/moment.js',
+        'ext/js/nprogress/nprogress.js',
+        'ext/js/bootstrap/alert.js',
+        'ext/js/bootstrap/button.js',
+        'ext/js/bootstrap/transition.js',
+        'ext/js/bootstrap/collapse.js',
+        'ext/js/bootstrap/dropdown.js',
+        'ext/js/bootstrap/tooltip.js',
       ],
     'scripts': [
         'src/script/common/service.coffee',

--- a/main/static/src/style/style.less
+++ b/main/static/src/style/style.less
@@ -1,6 +1,6 @@
-@import "../vendor/less/bootstrap/bootstrap";
-@import "../vendor/less/font-awesome/font-awesome";
-@import "../vendor/less/nprogress/nprogress";
+@import "../../ext/less/bootstrap/bootstrap";
+@import "../../ext/less/font-awesome/font-awesome";
+@import "../../ext/less/nprogress/nprogress";
 
 @import "base";
 @import "variables";

--- a/main/static/src/style/variables.less
+++ b/main/static/src/style/variables.less
@@ -1,5 +1,5 @@
-@fa-font-path:            "/p/vendor-fonts";
-@icon-font-path:          "/p/vendor-fonts/";
+@fa-font-path:            "/p/ext/font/font-awesome";
+@icon-font-path:          "/p/ext/font/bootstrap/";
 
 @footer-height:           (@line-height-computed * 5);
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   "devDependencies": {
     "bower": "~1",
     "grunt": "~0",
-    "grunt-contrib-watch": "~0",
     "grunt-bower-task": "~0",
-    "grunt-cli": "~0"
+    "grunt-cli": "~0",
+    "grunt-contrib-clean": "~0",
+    "grunt-contrib-watch": "~0"
   }
 }

--- a/run.py
+++ b/run.py
@@ -245,7 +245,7 @@ def install_dependencies():
 
   for dependency in get_dependencies('bower.json'):
     if not os.path.exists(os.path.join(DIR_BOWER_COMPONENTS, dependency)):
-      os.system('"%s" bower' % FILE_GRUNT)
+      os.system('"%s" ext' % FILE_GRUNT)
       break
 
 


### PR DESCRIPTION
Before merging this delete the `main/static/src/vendor` and `main/static/vendor-fonts` directories, since with this PR the external 3rd party libraries are being placed under `main/static/ext`.
- one folder for external libs so `vendor*` > `main/static/ext` 
- sorted the dependencies by name in `bower.json`
- removed parenthesises wherever possible from `Gruntfile.coffee`
