### PR TITLE
Using ordered dict for SCRIPTS

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import collections
 import os
 
 try:
@@ -33,13 +34,8 @@ STYLES = [
     'src/style/style.less',
   ]
 
-SCRIPTS_MODULES = [
-    'libs',
-    'scripts',
-  ]
-
-SCRIPTS = {
-    'libs': [
+SCRIPTS = collections.OrderedDict([
+    ('libs', [
         'ext/js/jquery/jquery.js',
         'ext/js/momentjs/moment.js',
         'ext/js/nprogress/nprogress.js',
@@ -49,13 +45,13 @@ SCRIPTS = {
         'ext/js/bootstrap/collapse.js',
         'ext/js/bootstrap/dropdown.js',
         'ext/js/bootstrap/tooltip.js',
-      ],
-    'scripts': [
+      ]),
+    ('scripts', [
         'src/script/common/service.coffee',
         'src/script/common/util.coffee',
         'src/script/site/app.coffee',
         'src/script/site/admin.coffee',
         'src/script/site/profile.coffee',
         'src/script/site/user.coffee',
-      ],
-  }
+      ]),
+  ])

--- a/main/templates/bit/script.html
+++ b/main/templates/bit/script.html
@@ -1,4 +1,4 @@
-# for module in config.SCRIPTS_MODULES
+# for module in config.SCRIPTS
   # if config.DEVELOPMENT
     # for script in config.SCRIPTS[module]
       <script src="/p/{{script.replace('.coffee', '.js').replace('src/script/', 'dst/script/')}}?{{config.CURRENT_VERSION_ID}}"></script>


### PR DESCRIPTION
As an alternative to #110 this PR also removes SCRIPTS_MODULES but leaves SCRIPTS as a dictionary, an OrrderedDict which maintains the order in which the items are inserted; see: http://docs.python.org/2/library/collections.html#ordereddict-objects
