### PR TITLE
methods kwd for permission_required decorator

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -115,15 +115,18 @@ def admin_required(f):
 permission_registered = _signals.signal('permission-registered')
 
 
-def permission_required(permission=None):
+def permission_required(permission=None, methods=None):
   def permission_decorator(f):
     # default to decorated function name as permission
     perm = permission or f.func_name
+    meths = [m.upper() for m in methods] if methods else None
 
     permission_registered.send(f, permission=perm)
 
     @functools.wraps(f)
     def decorated_function(*args, **kws):
+      if meths and flask.request.method.upper() not in meths:
+        return f(*args, **kws)
       if is_logged_in() and current_user_db().has_permission(perm):
         return f(*args, **kws)
       if not is_logged_in():


### PR DESCRIPTION
This change makes it easy to use the `permission_required`
decorator for the often occurring use case of allowing
read-access while restricting write-access.

If `methods` is specified, the decorator will only enforce the given
permission for requests with a `method` as in `methods`
(e.g., `@auth.permission_required('foo_w', methods=['POST'])` will
only check the user for permission `'foo_w'` in POST requests
but won't restrict other requests).
If `methods` is `None` (default), the permissions will be enforced
on all requests regardless of their method.

This enhanced version of the decorator can be combined with
the old one as in the example below. This only allows access to
`endpoint` in GET requests if the user has `'foo_r'` permission.
For POST requests the user needs both `'foo_r'` and `'foo_w'`:

``` python
@app.route('/endpoint/')
@auth.permission_required('foo_r')
@auth.permission_required('foo_w', methods=['POST'])
def endpoint():
  pass
```

For the typical usecase of allowing everyone to read: just
leave out the second line. 
Read for every logged in user: replace the second line with
`@auth.login_required`.

The order of the statements is not important as the permissions
are wrapped around each other. All of the permission guards have to
be passed in order to reach `endpoint`. Passing one of them does
**not** skip the others.
