### PR TITLE
Chevron for panel state

### DIFF
--- a/main/static/src/style/base.less
+++ b/main/static/src/style/base.less
@@ -18,3 +18,13 @@ body {
   margin: auto;
   display: block;
 }
+
+.panel-heading .accordion-toggle:after {
+  font-family: 'Glyphicons Halflings';
+  content: "\e114";
+  float: right;
+}
+
+.panel-heading .accordion-toggle.collapsed:after {
+  content: "\e080";
+}

--- a/main/templates/macro/forms.html
+++ b/main/templates/macro/forms.html
@@ -102,7 +102,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <h4 class="panel-title">
-        <a data-toggle="collapse" data-parent="#oauth" href="#{{slugify(name)}}">{{name}}</a>
+        <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#oauth" href="#{{slugify(name)}}">{{name}}</a>
         <i class="fa fa-check pull-right {{'hide' if not checkmark}}"></i>
       </h4>
     </div>


### PR DESCRIPTION
Adds chevron to panel title, showing their collapsed/expanded state and allowing another clickable thing (next to title) to expand/collapse panels. Used on "Admin Config" for third party OAuth settings.

Based on http://stackoverflow.com/questions/18325779/bootstrap-3-collapse-show-state-with-chevron-icon and http://jsfiddle.net/panchroma/3gYa3/ (mentioned in answers); note that I removed the `color: grey;` here, to allow a theme to control that. Perhaps there is a better `@` variable that could be used instead (dimmed text or so)?
