### PR TITLE
Renamed more explicit to avoid overlaps

### DIFF
--- a/main/static/src/script/site/user.coffee
+++ b/main/static/src/script/site/user.coffee
@@ -18,13 +18,13 @@ init_user_selections = ->
 
 
 user_select_row = ($element) ->
-  update_selections()
+  update_user_selections()
   ($ 'input[name=user_db]').each ->
     id = $element.val()
     ($ "##{id}").toggleClass 'warning', $element.is ':checked'
 
 
-update_selections = ->
+update_user_selections = ->
   selected = ($ 'input[name=user_db]:checked').length
   ($ '#user-actions').toggleClass 'hidden', selected == 0
   ($ '#user-merge').toggleClass 'hidden', selected < 2
@@ -61,7 +61,7 @@ init_user_delete_btn = ->
           return
         ($ "##{result.join(', #')}").fadeOut ->
           ($ this).remove()
-          update_selections()
+          update_user_selections()
           show_notification success_message.replace('{users}', user_keys.length), 'success'
 
 


### PR DESCRIPTION
Renamed `update_selections` to the more explicit `update_user_selections` to avoid function name overlaps when developers derive their applications from the `gae-init` family.

I learned the hard way that a copy-paste-find-replace `user.coffee` to `whatever.coffee` didn't brew in production... while it did on development. The `whatever`s didn't select properly... as in fact, the code was trying to make `user`s of `whatever` by over-re-using the `user`.`update_selections` :-)
