### PR TITLE
Fixed _skip_files pattern on GAE 1.9.1

### DIFF
--- a/main/appengine_config.py
+++ b/main/appengine_config.py
@@ -6,7 +6,7 @@ if os.environ.get('SERVER_SOFTWARE', '').startswith('Google App Engine'):
 else:
   import re
   from google.appengine.tools.devappserver2.python import stubs
-  re_ = stubs.FakeFile._skip_files.pattern.replace('|(?:^lib/.*)|', '|')
+  re_ = stubs.FakeFile._skip_files.pattern.replace('|^lib/.*', '')
   re_ = re.compile(re_)
   stubs.FakeFile._skip_files = re_
   sys.path.insert(0, 'lib')


### PR DESCRIPTION
as an alternative, we can add `--allow_skipped_files` option
in run.py

``` python
run_command = '''
      dev_appserver.py %s
      --host %s
      --port %s
      --admin_port %s
      --storage_path=%s
      --clear_datastore=%s
      --skip_sdk_update_check
      --allow_skipped_files
    ''' % (DIR_MAIN, ARGS.host, port, port + 1, DIR_STORAGE, clear)
```

and simplify appengine_config.py

``` python
import os
import sys

if os.environ.get('SERVER_SOFTWARE', '').startswith('Google App Engine'):
  sys.path.insert(0, 'lib.zip')
else:
  sys.path.insert(0, 'lib')
```

but it will cause big difference between dev/production environment (dev server will have access to all `skip_files`)
