### PR TITLE
Added safe filter for next_link caption

### DIFF
--- a/main/templates/macro/utils.html
+++ b/main/templates/macro/utils.html
@@ -27,7 +27,7 @@
 # macro next_link(more_url, caption)
   # if more_url
     <ul class="pager">
-      <li><a href="{{more_url}}" rel="nofollow">{{caption if caption else 'Next Page'}}</a></li>
+      <li><a href="{{more_url}}" rel="nofollow">{{caption|safe if caption else 'Next Page'}}</a></li>
     </ul>
   # endif
 # endmacro


### PR DESCRIPTION
Disable text escaping  and allow caption like

``` html
Next page &rarr;
```
