### PR TITLE
Pip only when necessary

### DIFF
--- a/run.py
+++ b/run.py
@@ -87,7 +87,7 @@ DIR_LIB = os.path.join(DIR_MAIN, 'lib')
 DIR_LIBX = os.path.join(DIR_MAIN, 'libx')
 FILE_LIB = os.path.join(DIR_MAIN, 'lib.zip')
 FILE_LIB_REQUIREMENTS = 'requirements.txt'
-FILE_PIP_RUN = os.path.join(DIR_TEMP, 'pip_guard.lck')
+FILE_PIP_RUN = os.path.join(DIR_TEMP, 'pip.guard')
 
 DIR_BIN = os.path.join(DIR_NODE_MODULES, '.bin')
 FILE_COFFEE = os.path.join(DIR_BIN, 'coffee')


### PR DESCRIPTION
This pull request adds and modifies a pip_guard lockfile to temp each time install_py_libs() is called. The file is used in later runs to check if our requirements.txt is newer. If so pip install is run if not it's skipped. run.py -C removes the file.

fixes https://github.com/gae-init/gae-init-babel/issues/39
