### PR TITLE
args after --appserver-args are passed to dev_appserver.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -585,13 +585,9 @@ def run_start():
 
 
 def run():
-  if len(sys.argv) == 1:
+  if len(sys.argv) == 1 or (ARGS.args and not ARGS.start):
     PARSER.print_help()
     sys.exit(1)
-
-  if ARGS.args and not ARGS.start:
-      PARSER.print_help()
-      sys.exit(1)
 
   os.chdir(os.path.dirname(os.path.realpath(__file__)))
 


### PR DESCRIPTION
sometimes it's helpful to be able to pass args on to `dev_appserver.py`

example use: `./run.py -s --appserver-args --require_indexes` in case you're trying to reduce index definitions with the zigzag merge algorithm: https://developers.google.com/appengine/articles/indexselection#Improved_Query_Planner
