### PR TITLE
by default ignore cursor argument for update_query_argument

### DIFF
--- a/main/util.py
+++ b/main/util.py
@@ -194,7 +194,7 @@ def is_valid_username(username):
   return True if re.match('^[a-z0-9]+(?:[\.][a-z0-9]+)*$', username) else False
 
 
-def update_query_argument(name, value=None, ignore=None, is_list=False):
+def update_query_argument(name, value=None, ignore='cursor', is_list=False):
   ignore = ignore.split(',') if isinstance(ignore, str) else ignore or []
   arguments = {}
   for key, val in flask.request.args.items():


### PR DESCRIPTION
this hits me again and again and i think it's sane to by default reset the `cursor` argument when updating query arguments, as there'll be an error in most cases otherwise.
