### PR TITLE
Fix guards creation

### DIFF
--- a/run.py
+++ b/run.py
@@ -371,6 +371,7 @@ def clean_py_libs():
 
 
 def install_dependencies():
+  make_dirs(DIR_TEMP)
   if check_npm_should_run():
     with open(FILE_NPM_GUARD, 'w') as npm_guard:
       npm_guard.write('Prevents npm execution if newer than package.json')
@@ -397,7 +398,6 @@ def check_for_update():
         urllib.urlencode({'version': main.__version__}),
       )
     response = urllib2.urlopen(request)
-    make_dirs(DIR_TEMP)
     with open(FILE_UPDATE, 'w') as update_json:
       update_json.write(response.read())
   except urllib2.HTTPError:


### PR DESCRIPTION
```
git clone https://github.com/gae-init/gae-init.git
cd gae-init
./run.py -s
Traceback (most recent call last):
  File "./run.py", line 635, in <module>
    run()
  File "./run.py", line 613, in run
    install_dependencies()
  File "./run.py", line 375, in install_dependencies
    with open(FILE_NPM_GUARD, 'w') as npm_guard:
IOError: [Errno 2] No such file or directory: 'temp/npm.guard'
```

Oops...
