### PR TITLE
fix try-except-all block for better debugging

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -10,9 +10,11 @@ try:
   # This part is surrounded in try/except because the config.py file is
   # also used in the run.py script which is used to compile/minify the client
   # side files (*.less, *.coffee, *.js) and is not aware of the GAE
-  from datetime import datetime
   from google.appengine.api import app_identity
-
+except ImportError:
+  pass
+else:
+  from datetime import datetime
   CURRENT_VERSION_ID = os.environ.get('CURRENT_VERSION_ID')
   CURRENT_VERSION_NAME = CURRENT_VERSION_ID.split('.')[0]
   CURRENT_VERSION_TIMESTAMP = long(CURRENT_VERSION_ID.split('.')[1]) >> 28
@@ -26,8 +28,6 @@ try:
 
   CONFIG_DB = model.Config.get_master_db()
   SECRET_KEY = CONFIG_DB.flask_secret_key.encode('ascii')
-except:
-  pass
 
 DEFAULT_DB_LIMIT = 64
 


### PR DESCRIPTION
restricts the caught exception to missing gae. Only if gae is present the else block is executed but doesn't gulp possible other exceptions anymore.
