### PR TITLE
Moved brand_name inside title block

### DIFF
--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -7,9 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>
       # block title
-        {{title + ' |' if title}}
+        {{title + ' | ' if title}}{{config.CONFIG_DB.brand_name}}
       # endblock
-      {{config.CONFIG_DB.brand_name}}
     </title>
     # include 'bit/style.html'
     # block head


### PR DESCRIPTION
Moved `CONFIG_DB.brand_name` inside `title` block of `main/templates/base.html`. This allows derived projects to override the default `title` block (including the brand name by default) with their own (perhaps not using the brand name at all).
