### PR TITLE
Auto merge verified accounts

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -357,6 +357,16 @@ def decorator_order_guard(f, decorator_name):
 
 
 def create_user_db(auth_id, name, username, email='', verified=False, **params):
+  email = email.lower()
+  if verified and email:
+    user_dbs, _ = model.User.get_dbs(email=email, verified=True, limit=2)
+    if len(user_dbs) == 1:
+      user_db = user_dbs[0]
+      user_db.auth_ids.append(auth_id)
+      user_db.put()
+      task.new_user_notification(user_db)
+      return user_db
+
   username = unidecode.unidecode(username.split('@')[0].lower()).strip()
   username = re.sub(r'[\W_]+', '.', username)
   new_username = username
@@ -367,7 +377,7 @@ def create_user_db(auth_id, name, username, email='', verified=False, **params):
 
   user_db = model.User(
       name=name,
-      email=email.lower(),
+      email=email,
       username=new_username,
       auth_ids=[auth_id],
       verified=verified,


### PR DESCRIPTION
Creation of the new user accounts when the `auth_id` wasn't found is changing to:
- If verified provider (Google, Yahoo!, etc) check first if that email already exists and it's verified.
- If it exists then add that `auth_id` to the existing user and return that one
- if it doesn't exist.. do the usual :)

It will work with a combination of #200 and won't be merged as a stand alone PR.
