### PR TITLE
Simple change according to Moment docs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "bootstrap": "~3",
     "font-awesome": "~4",
     "jquery": "~2",
-    "momentjs": "~2",
+    "moment": "~2",
     "nprogress": "https://github.com/lipis/nprogress.git#master"
   },
   "exportsOverride": {
@@ -21,7 +21,7 @@
     "jquery": {
       "js": "dist/jquery.js"
     },
-    "momentjs": {
+    "moment": {
       "js": "*.js"
     },
     "nprogress": {

--- a/main/config.py
+++ b/main/config.py
@@ -42,7 +42,7 @@ STYLES = [
 SCRIPTS = [
     ('libs', [
         'ext/js/jquery/jquery.js',
-        'ext/js/momentjs/moment.js',
+        'ext/js/moment/moment.js',
         'ext/js/nprogress/nprogress.js',
         'ext/js/bootstrap/alert.js',
         'ext/js/bootstrap/button.js',


### PR DESCRIPTION
On http://momentjs.com/ and http://momentjs.com/docs/#/use-it/bower/ it shows that `bower install moment --save` would be the typical approach to add Moment to a project using the Bower CLI. See also https://github.com/moment/moment-timezone/blob/develop/bower.json for how moment-timezone uses `moment` in their `bower.json` file.

Furthermore, using either `bower info moment` or `bower info momentjs` shows `name: 'moment',` in the retrieved record. I think `momentjs` is kept for historical reasons, but unfortunately couldn't find a reference to when this might have changed to just `moment`...
