### PR TITLE
Replacing Flask-OAuth with Flask-OAuthlib

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -4,7 +4,7 @@ import functools
 import re
 
 from flask.ext import login
-from flask.ext import oauth
+from flask.ext.oauthlib import client as oauth
 from google.appengine.api import users
 from google.appengine.ext import ndb
 import flask
@@ -227,9 +227,7 @@ def retrieve_user_from_google(google_user):
 ###############################################################################
 twitter_oauth = oauth.OAuth()
 
-
-twitter = twitter_oauth.remote_app(
-    'twitter',
+app.config['TWITTER'] = dict(
     base_url='https://api.twitter.com/1.1/',
     request_token_url='https://api.twitter.com/oauth/request_token',
     access_token_url='https://api.twitter.com/oauth/access_token',
@@ -237,6 +235,9 @@ twitter = twitter_oauth.remote_app(
     consumer_key=config.CONFIG_DB.twitter_consumer_key,
     consumer_secret=config.CONFIG_DB.twitter_consumer_secret,
   )
+
+twitter = twitter_oauth.remote_app('twitter', app_key='TWITTER')
+twitter_oauth.init_app(app)
 
 
 @app.route('/_s/callback/twitter/oauth-authorized/')
@@ -291,8 +292,7 @@ def retrieve_user_from_twitter(response):
 ###############################################################################
 facebook_oauth = oauth.OAuth()
 
-facebook = facebook_oauth.remote_app(
-    'facebook',
+app.config['FACEBOOK'] = dict(
     base_url='https://graph.facebook.com/',
     request_token_url=None,
     access_token_url='/oauth/access_token',
@@ -301,6 +301,9 @@ facebook = facebook_oauth.remote_app(
     consumer_secret=config.CONFIG_DB.facebook_app_secret,
     request_token_params={'scope': 'email'},
   )
+
+facebook = facebook_oauth.remote_app('facebook', app_key='FACEBOOK')
+facebook_oauth.init_app(app)
 
 
 @app.route('/_s/callback/facebook/oauth-authorized/')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 blinker==1.3
 flask==0.10.1
 flask-login==0.2.11
-git+https://github.com/mitsuhiko/flask-oauth.git@0.13
+flask-oauthlib==0.7.0
 flask-wtf==0.10.2
 unidecode==0.4.16


### PR DESCRIPTION
Update to the Flask-OAuthlib 0.7.0 as _"Flask-OAuthlib is designed as a replacement for Flask-OAuth"_ and that _"the client part of Flask-OAuthlib shares the same API as Flask-OAuth, which is pretty and simple"_ (see https://flask-oauthlib.readthedocs.org/en/latest/ and https://github.com/lepture/flask-oauthlib).

If you experience déjà-vu: see https://github.com/gae-init/gae-init/pull/56 for a previous PR on this subject.
