### PR TITLE
Handle case in which email is None (as GitHub can provide)

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -358,7 +358,7 @@ def decorator_order_guard(f, decorator_name):
 
 
 def create_user_db(auth_id, name, username, email='', verified=False, **props):
-  email = email.lower()
+  email = email.lower() if email else ''
   if verified and email:
     user_dbs, user_cr = model.User.get_dbs(email=email, verified=True, limit=2)
     if len(user_dbs) == 1:


### PR DESCRIPTION
As observed in dealing with GitHub in https://github.com/gae-init/gae-init-auth/pull/39, it is possible that the `email` parameter in calling `create_user_db` is in fact `None`; which cannot be `lower()`-ed as-is. This can occur for example when using a GitHub account with no public email set.
