### PR TITLE
Separating auth config properties

### DIFF
--- a/main/model/__init__.py
+++ b/main/model/__init__.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
 from .base import Base
+from .config_auth import ConfigAuth
 from .config import Config
 from .user import User

--- a/main/model/config.py
+++ b/main/model/config.py
@@ -9,7 +9,7 @@ import model
 import util
 
 
-class Config(model.Base):
+class Config(model.Base, model.ConfigAuth):
   analytics_id = ndb.StringProperty(default='')
   announcement_html = ndb.TextProperty(default='')
   announcement_type = ndb.StringProperty(default='info', choices=[
@@ -19,18 +19,12 @@ class Config(model.Base):
   brand_name = ndb.StringProperty(default=config.APPLICATION_ID)
   check_unique_email = ndb.BooleanProperty(default=True)
   email_authentication = ndb.BooleanProperty(default=False)
-  facebook_app_id = ndb.StringProperty(default='')
-  facebook_app_secret = ndb.StringProperty(default='')
   feedback_email = ndb.StringProperty(default='')
   flask_secret_key = ndb.StringProperty(default=util.uuid())
-  github_client_id = ndb.StringProperty(default='')
-  github_client_secret = ndb.StringProperty(default='')
   notify_on_new_user = ndb.BooleanProperty(default=True)
   recaptcha_private_key = ndb.StringProperty(default='')
   recaptcha_public_key = ndb.StringProperty(default='')
   salt = ndb.StringProperty(default=util.uuid())
-  twitter_consumer_key = ndb.StringProperty(default='')
-  twitter_consumer_secret = ndb.StringProperty(default='')
   verify_email = ndb.BooleanProperty(default=True)
 
   @property
@@ -42,20 +36,8 @@ class Config(model.Base):
     return bool(self.email_authentication and self.feedback_email and self.verify_email)
 
   @property
-  def has_facebook(self):
-    return bool(self.facebook_app_id and self.facebook_app_secret)
-
-  @property
-  def has_github(self):
-    return bool(self.github_client_id and self.github_client_secret)
-
-  @property
   def has_recaptcha(self):
     return bool(self.recaptcha_private_key and self.recaptcha_public_key)
-
-  @property
-  def has_twitter(self):
-    return bool(self.twitter_consumer_key and self.twitter_consumer_secret)
 
   _PROPERTIES = model.Base._PROPERTIES.union({
       'analytics_id',
@@ -65,20 +47,14 @@ class Config(model.Base):
       'brand_name',
       'check_unique_email',
       'email_authentication',
-      'facebook_app_id',
-      'facebook_app_secret',
       'feedback_email',
       'flask_secret_key',
-      'github_client_id',
-      'github_client_secret',
       'notify_on_new_user',
       'recaptcha_private_key',
       'recaptcha_public_key',
       'salt',
-      'twitter_consumer_key',
-      'twitter_consumer_secret',
       'verify_email',
-    })
+    }).union(model.ConfigAuth._PROPERTIES)
 
   @classmethod
   def get_master_db(cls):

--- a/main/model/config_auth.py
+++ b/main/model/config_auth.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+
+from google.appengine.ext import ndb
+
+
+class ConfigAuth(object):
+  facebook_app_id = ndb.StringProperty(default='')
+  facebook_app_secret = ndb.StringProperty(default='')
+  github_client_id = ndb.StringProperty(default='')
+  github_client_secret = ndb.StringProperty(default='')
+  twitter_consumer_key = ndb.StringProperty(default='')
+  twitter_consumer_secret = ndb.StringProperty(default='')
+
+  @property
+  def has_facebook(self):
+    return bool(self.facebook_app_id and self.facebook_app_secret)
+
+  @property
+  def has_github(self):
+    return bool(self.github_client_id and self.github_client_secret)
+
+  @property
+  def has_twitter(self):
+    return bool(self.twitter_consumer_key and self.twitter_consumer_secret)
+
+  _PROPERTIES = {
+      'facebook_app_id',
+      'facebook_app_secret',
+      'github_client_id',
+      'github_client_secret',
+      'twitter_consumer_key',
+      'twitter_consumer_secret',
+    }


### PR DESCRIPTION
If more auth will be integrated the config will become too messy with all the auth stuff... what about separating them?! 

Another idea would be to have the two classes inside the same file... which I don't like much.. :)

Related to #253 
