### PR TITLE
Fix unicode email and username for md5()

### DIFF
--- a/main/model/user.py
+++ b/main/model/user.py
@@ -28,7 +28,8 @@ class User(model.Base):
 
   def avatar_url_size(self, size=None):
     return '//gravatar.com/avatar/%(hash)s?d=identicon&r=x%(size)s' % {
-        'hash': hashlib.md5(self.email or self.username).hexdigest(),
+        'hash': hashlib.md5(
+            (self.email or self.username).encode('utf-8')).hexdigest(),
         'size': '&s=%d' % size if size > 0 else '',
       }
   avatar_url = property(avatar_url_size)


### PR DESCRIPTION
``` python
import hashlib
str = 'This is a test string'
str_unicode = u'Это тестовая строка'
hashlib.md5(str).hexdigest()
hashlib.md5(str.encode('utf-8')).hexdigest()
hashlib.md5(str_unicode.encode('utf-8')).hexdigest()
hashlib.md5(str_unicode).hexdigest()
```

console output
``` shell
'c639efc1e98762233743a75e7798dd9c'
'c639efc1e98762233743a75e7798dd9c'
'76f0fadc31b6fa63243ee740d8b5b81b'
Traceback (most recent call last):
  File "<input>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordin
al not in range(128)
```