### PR TITLE
Ability to add new users for admins

### DIFF
--- a/main/templates/user/user_list.html
+++ b/main/templates/user/user_list.html
@@ -8,6 +8,10 @@
 # block admin_content
   <div class="panel panel-default">
     <div class="panel-body">
+      <a class="btn btn-sm btn-primary" href="{{url_for('user_update')}}">
+        <span class="fa fa-user-plus"></span> New User
+      </a>
+
       <div class="btn-group btn-group-sm">
         <button type="button" class="btn btn-primary" disabled >Limit</button>
         {{utils.filter_by_link('limit', 16)}}
@@ -106,7 +110,7 @@
             </td>
             <td class="text-nowrap">
               {{user_db.email}}
-              # if user_db.verified
+              # if user_db.email and user_db.verified
                 <span class="fa fa-check text-success" title="Verified"></span>
               # endif
               <br>

--- a/main/templates/user/user_update.html
+++ b/main/templates/user/user_update.html
@@ -7,7 +7,7 @@
     <h1>
       {{utils.back_link('Back to user list', 'user_list', order='-modified', active=user_db.active)}}
       {{title}}
-      # if current_user.id == user_db.key.id()
+      # if current_user.user_db.key == user_db.key
         <small><span class="fa fa-hand-o-left" title="You"></span></small>
       # endif
     </h1>
@@ -20,7 +20,7 @@
         {{forms.text_field(form.username, autocomplete='off')}}
         # include 'user/user_email_field.html'
         {{forms.checkbox_field(form.verified)}}
-        # if current_user.id != user_db.key.id()
+        # if current_user.user_db.key != user_db.key
           {{forms.checkbox_field(form.admin)}}
           {{forms.checkbox_field(form.active)}}
         # else
@@ -42,7 +42,10 @@
       <div class="col-md-6 col-sm-12">
         <div class="form-group">
           <label class="control-label">Accounts</label>
-          <table class="table table-bordered table-hover">
+          <div class="alert alert-warning {{'hide' if user_db.password_hash or user_db.auth_ids}}">
+            No associated accounts
+          </div>
+          <table class="table table-bordered table-hover {{'hide' if not (user_db.password_hash or user_db.auth_ids)}}">
             <thead>
               <tr>
                 <th><span class="fa fa-key"></span></th>
@@ -70,8 +73,12 @@
     <hr>
     <div class="row">
       <div class="col-md-6 col-md-offset-3">
-        <button type="submit" class="btn btn-primary btn-lg btn-block btn-loading" data-loading-text="Updating..">
-          Update
+        <button type="submit" class="btn btn-primary btn-lg btn-block btn-loading" data-loading-text="Please wait..">
+          # if user_db.key
+            Update
+          # else
+            Create
+          # endif
         </button>
       </div>
     </div>

--- a/main/user.py
+++ b/main/user.py
@@ -82,10 +82,14 @@ class UserUpdateForm(wtf.Form):
     UserUpdateForm._permission_choices.add(permission)
 
 
+@app.route('/user/create/', methods=['GET', 'POST'])
 @app.route('/user/<int:user_id>/update/', methods=['GET', 'POST'])
 @auth.admin_required
-def user_update(user_id):
-  user_db = model.User.get_by_id(user_id)
+def user_update(user_id=0):
+  if user_id:
+    user_db = model.User.get_by_id(user_id)
+  else:
+    user_db = model.User(name='', username='')
   if not user_db:
     flask.abort(404)
 
@@ -100,7 +104,7 @@ def user_update(user_id):
       form.username.errors.append('This username is already taken.')
     else:
       form.populate_obj(user_db)
-      if auth.current_user_id() == user_db.key.id():
+      if auth.current_user_key() == user_db.key:
         user_db.admin = True
         user_db.active = True
       user_db.put()
@@ -113,7 +117,7 @@ def user_update(user_id):
 
   return flask.render_template(
       'user/user_update.html',
-      title=user_db.name,
+      title=user_db.name or 'New User',
       html_class='user-update',
       form=form,
       user_db=user_db,


### PR DESCRIPTION
Even though it looks like the user won't be able to login to that newly created entity.. if there is a verified email and the person has that in the auth provider it will be automatically matched or the user could use the forgot password.. either case is very very useful and we needed that many times at work.

------
Not sure yet if there will be a button or part of the more action menu which will always be there if that's the case

![screen shot 2015-01-24 at 22 47 18](https://cloud.githubusercontent.com/assets/125676/5889184/2d337eb2-a41b-11e4-8731-aab674183ea0.png)

![screen shot 2015-01-24 at 22 47 14](https://cloud.githubusercontent.com/assets/125676/5889185/2e70db26-a41b-11e4-8b43-30e899bf63ce.png)
