### PR TITLE
Refactoring fields

### DIFF
--- a/main/api/fields.py
+++ b/main/api/fields.py
@@ -3,6 +3,7 @@
 import urllib
 
 from flask.ext.restful import fields
+from flask.ext.restful.fields import *
 
 
 class BlobKey(fields.Raw):

--- a/main/model/config.py
+++ b/main/model/config.py
@@ -2,9 +2,9 @@
 
 from __future__ import absolute_import
 
-from flask.ext.restful import fields
 from google.appengine.ext import ndb
 
+from api import fields
 import config
 import model
 import util

--- a/main/model/config_auth.py
+++ b/main/model/config_auth.py
@@ -2,9 +2,9 @@
 
 from __future__ import absolute_import
 
-from flask.ext.restful import fields
 from google.appengine.ext import ndb
 
+from api import fields
 import model
 
 

--- a/main/model/user.py
+++ b/main/model/user.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import
 
 import hashlib
 
-from flask.ext.restful import fields
 from google.appengine.ext import ndb
 
+from api import fields
 import model
 import util
 import config


### PR DESCRIPTION
I cam across this issue when I wanted to insert, for example, a new datetime field into the User model and couldn't use the `api.fields.DateTimeField` as the `fields` was already imported from `restful`. Not sure if that's the best solution.. WDYT? @gmist 