### PR TITLE
Ability to filter by a (urlsafe) ndb key with different button text

### DIFF
--- a/main/templates/macro/utils.html
+++ b/main/templates/macro/utils.html
@@ -11,12 +11,14 @@
 # endmacro
 
 
-# macro filter_by_link(property, value, icon=None, ignore='cursor', is_list=False, hash=None)
+# macro filter_by_link(property, value, icon=None, ignore='cursor', is_list=False, hash=None, label=None)
   # set value = '%s' % value
   <a href="{{update_query_argument(property, None if request.args.get(property) == value else value, ignore, is_list)}}{{'#%s' % hash if hash}}"
      class="btn btn-default {{'active' if value in request.args.get(property, '').split(',')}}" rel="nofollow">
     # if icon
       <span class="fa fa-{{icon}}"></span>
+    # elif label
+      {{label}}
     # else
       {{value}}
     # endif

--- a/main/util.py
+++ b/main/util.py
@@ -31,6 +31,8 @@ def param(name, cast=None):
       return value.lower() in ['true', 'yes', 'y', '1', '']
     if cast is list:
       return value.split(',') if len(value) > 0 else []
+    if cast is ndb.Key:
+      return ndb.Key(urlsafe=value)
     return cast(value)
   return value
 


### PR DESCRIPTION
For anyone who wants to dynamically generate the filter buttons on the fly using a KeyProperty from a linked model. This is how I'm using it:

```
<div class="btn-group btn-group-sm">
    <button type="button" class="btn btn-info" disabled >Genre</button>
    # for genre_db in genre_dbs
      {{utils.filter_by_link('genre_key', genre_db.key.urlsafe(), button_text=genre_db.key.get().name)}}
    # endfor
</div>
```

Which renders:
![image](https://cloud.githubusercontent.com/assets/2013388/6091191/cb07acda-ae52-11e4-91c5-09c98ffc2b4e.png)

