### PR TITLE
Fixed run_command path issue

### DIFF
--- a/run.py
+++ b/run.py
@@ -619,7 +619,7 @@ def run_start():
   make_dirs(DIR_STORAGE)
   clear = 'yes' if ARGS.flush else 'no'
   port = int(ARGS.port)
-  base_cmd = '"python -u %s"' if IS_WINDOWS else '"%s"'
+  base_cmd = 'python -u "%s"' if IS_WINDOWS else '"%s"'
   run_command = ' '.join(map(str, [
       base_cmd % os.path.join(fix_gcloud_gae_path(), 'dev_appserver.py'),
       DIR_MAIN,


### PR DESCRIPTION
I was getting the following error ```python: can't open file 'C:\Program': [Errno 2] No such file or directory```
And this fix resolved it. Hopefully it's useful. :smile: 