### PR TITLE
Header set to default instead of inverse

### DIFF
--- a/main/templates/bit/header.html
+++ b/main/templates/bit/header.html
@@ -1,4 +1,4 @@
-<header class="navbar navbar-inverse navbar-fixed-top" role="banner">
+<header class="navbar navbar-default navbar-fixed-top" role="banner">
   <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">


### PR DESCRIPTION
It works better with the default themes from Bootswatch or when manually changing your self the color of the header..

#### Before
![screen shot 2015-03-11 at 00 12 27](https://cloud.githubusercontent.com/assets/125676/6587325/1bb856c2-c783-11e4-866c-7a74b863b9c5.png)

#### After
![screen shot 2015-03-11 at 00 12 37](https://cloud.githubusercontent.com/assets/125676/6587322/1a1224ce-c783-11e4-9f67-cb581d7c4533.png)
