### PR TITLE
Added margin for btn-social-icon on auth pages

### DIFF
--- a/main/static/src/style/signin.less
+++ b/main/static/src/style/signin.less
@@ -83,6 +83,13 @@
   .button-variant(@color, @color-bg, rgba(0, 0, 0, 0.2));
 }
 
+.auth {
+  .btn-social-icon {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
 .remember {
   .text-center;
   label {


### PR DESCRIPTION
#### Before
![screen shot 2015-03-11 at 00 10 29](https://cloud.githubusercontent.com/assets/125676/6587301/cef7016c-c782-11e4-81b9-5ab39389a253.png)

#### After
![screen shot 2015-03-11 at 00 10 16](https://cloud.githubusercontent.com/assets/125676/6587303/d42b521e-c782-11e4-87ce-5187a730db95.png)
