### PR TITLE
Refactor User's API

### DIFF
--- a/main/api/v1/user.py
+++ b/main/api/v1/user.py
@@ -14,8 +14,8 @@ import util
 from main import api_v1
 
 
-@api_v1.resource('/users/', endpoint='api.users')
-class UsersAPI(restful.Resource):
+@api_v1.resource('/user/', endpoint='api.user.list')
+class UserListAPI(restful.Resource):
   @auth.admin_required
   def get(self):
     user_keys = util.param('user_keys', list)

--- a/main/control/user.py
+++ b/main/control/user.py
@@ -21,7 +21,7 @@ from main import app
 ###############################################################################
 # User List
 ###############################################################################
-@app.route('/admin/users/')
+@app.route('/admin/user/')
 @auth.admin_required
 def user_list():
   user_dbs, user_cursor = model.User.get_dbs(email=util.param('email'))
@@ -33,7 +33,7 @@ def user_list():
       title='User List',
       user_dbs=user_dbs,
       next_url=util.generate_next_url(user_cursor),
-      api_url=flask.url_for('api.users'),
+      api_url=flask.url_for('api.user.list'),
       permissions=sorted(set(permissions)),
     )
 
@@ -341,7 +341,7 @@ def user_merge():
       merged_user_db=merged_user_db,
       form=form,
       auth_ids=auth_ids,
-      api_url=flask.url_for('api.users', user_keys=','.join(user_keys)),
+      api_url=flask.url_for('api.user.list', user_keys=','.join(user_keys)),
     )
 
 

--- a/main/templates/user/user_list.html
+++ b/main/templates/user/user_list.html
@@ -58,7 +58,7 @@
         <ul class="dropdown-menu">
           <li>
             <a id="user-delete"
-                data-api-url="{{url_for('api.users')}}"
+                data-api-url="{{url_for('api.user.list')}}"
                 data-confirm="Are you sure you want to delete {users} selected user(s)?"
                 data-success="{users} user(s) deleted."
                 data-error="Something went wrong while deleting. Please try again."


### PR DESCRIPTION
(Regardless of what is going to happen with #331)

I think it scales better and there are no issues with [irregular plurals](http://web2.uvcs.uvic.ca/elc/studyzone/330/grammar/irrplu.htm).

From other examples ([restless](https://flask-restless.readthedocs.org/en/latest/customizing.html#http-methods) & [restful](https://flask-restful.readthedocs.org/en/0.3.2/quickstart.html#full-example)) the core URL is not changing for single entities, so all you have to do is to add the key/id to the URL of the list.

-----------

Also in real life there are cases that entities are changed by signed-in users and not only by admins for the same models.. so what about have a prefix admin for admin an no prefix for normal users. For example if there is a new model called `Contact`.. it would look like this:

```python
# Normal Users
@api.resource('/api/v1/contact/', endpoint='api.contact.list')
class ContactListAPI(restful.Resource):
...
@api.resource('/api/v1/contact/<string:contact_key>/', endpoint='api.contact')
class ContactAPI(restful.Resource):
...

# Admins Only
@api.resource('/api/v1/admin/contact/', endpoint='api.admin.contact.list')
class AdminContactListAPI(restful.Resource):
...
@api.resource('/api/v1/admin/contact/<string:contact_key>/', endpoint='api.admin.contact')
class AdminContactAPI(restful.Resource):
...
```

-----

If the above makes any sense.. then most likely even for the UserAPI we will use the admin prefix for `admin_required` and introduce maybe for logged in users the ability to change the individual properties perhaps.. WDYT?