### PR TITLE
Updated endpoints for OAuth

### DIFF
--- a/main/auth/bitbucket.py
+++ b/main/auth/bitbucket.py
@@ -23,6 +23,7 @@ bitbucket = auth.create_oauth_app(bitbucket_config, 'bitbucket')
 
 
 @app.route('/_s/callback/bitbucket/oauth-authorized/')
+@app.route('/api/auth/callback/bitbucket/')
 def bitbucket_authorized():
   response = bitbucket.authorized_response()
   if response is None:

--- a/main/auth/dropbox.py
+++ b/main/auth/dropbox.py
@@ -23,6 +23,7 @@ dropbox = auth.create_oauth_app(dropbox_config, 'dropbox')
 
 
 @app.route('/_s/callback/dropbox/oauth-authorized/')
+@app.route('/api/auth/callback/dropbox/')
 def dropbox_authorized():
   response = dropbox.authorized_response()
   if response is None:

--- a/main/auth/facebook.py
+++ b/main/auth/facebook.py
@@ -23,6 +23,7 @@ facebook = auth.create_oauth_app(facebook_config, 'facebook')
 
 
 @app.route('/_s/callback/facebook/oauth-authorized/')
+@app.route('/api/auth/callback/facebook/')
 def facebook_authorized():
   response = facebook.authorized_response()
   if response is None:

--- a/main/auth/gae.py
+++ b/main/auth/gae.py
@@ -20,6 +20,7 @@ def signin_gae():
 
 
 @app.route('/_s/callback/gae/authorized/')
+@app.route('/api/auth/callback/gae/')
 def gae_authorized():
   gae_user = users.get_current_user()
   if gae_user is None:

--- a/main/auth/github.py
+++ b/main/auth/github.py
@@ -24,6 +24,7 @@ github = auth.create_oauth_app(github_config, 'github')
 
 
 @app.route('/_s/callback/github/oauth-authorized/')
+@app.route('/api/auth/callback/github/')
 def github_authorized():
   response = github.authorized_response()
   if response is None:

--- a/main/auth/google.py
+++ b/main/auth/google.py
@@ -24,6 +24,7 @@ google = auth.create_oauth_app(google_config, 'google')
 
 
 @app.route('/_s/callback/google/oauth-authorized/')
+@app.route('/api/auth/callback/google/')
 def google_authorized():
   response = google.authorized_response()
   if response is None:

--- a/main/auth/instagram.py
+++ b/main/auth/instagram.py
@@ -22,6 +22,7 @@ instagram = auth.create_oauth_app(instagram_config, 'instagram')
 
 
 @app.route('/_s/callback/instagram/oauth-authorized/')
+@app.route('/api/auth/callback/instagram/')
 def instagram_authorized():
   response = instagram.authorized_response()
   if response is None:

--- a/main/auth/linkedin.py
+++ b/main/auth/linkedin.py
@@ -35,6 +35,7 @@ linkedin.pre_request = change_linkedin_query
 
 
 @app.route('/_s/callback/linkedin/oauth-authorized/')
+@app.route('/api/auth/callback/linkedin/')
 def linkedin_authorized():
   response = linkedin.authorized_response()
   if response is None:

--- a/main/auth/microsoft.py
+++ b/main/auth/microsoft.py
@@ -24,6 +24,7 @@ microsoft = auth.create_oauth_app(microsoft_config, 'microsoft')
 
 
 @app.route('/_s/callback/microsoft/oauth-authorized/')
+@app.route('/api/auth/callback/microsoft/')
 def microsoft_authorized():
   response = microsoft.authorized_response()
   if response is None:

--- a/main/auth/twitter.py
+++ b/main/auth/twitter.py
@@ -23,6 +23,7 @@ twitter = auth.create_oauth_app(twitter_config, 'twitter')
 
 
 @app.route('/_s/callback/twitter/oauth-authorized/')
+@app.route('/api/auth/callback/twitter/')
 def twitter_authorized():
   response = twitter.authorized_response()
   if response is None:

--- a/main/auth/vk.py
+++ b/main/auth/vk.py
@@ -22,6 +22,7 @@ vk = auth.create_oauth_app(vk_config, 'vk')
 
 
 @app.route('/_s/callback/vk/oauth-authorized/')
+@app.route('/api/auth/callback/vk/')
 def vk_authorized():
   response = vk.authorized_response()
   if response is None:

--- a/main/auth/yahoo.py
+++ b/main/auth/yahoo.py
@@ -22,6 +22,7 @@ yahoo = auth.create_oauth_app(yahoo_config, 'yahoo')
 
 
 @app.route('/_s/callback/yahoo/oauth-authorized/')
+@app.route('/api/auth/callback/yahoo/')
 def yahoo_authorized():
   response = yahoo.authorized_response()
   if response is None:


### PR DESCRIPTION
Since we deprecated the `/_s/` maybe we should update these endpoints as well.. but I'll leave the old ones for backwards compatibility as this a bit pain to update :)


Maybe even to something smaller?
```
/api/callback/brand/auth/
```

any other ideas?