### PR TITLE
Removed default http for callbacks and deprecated URLs

### DIFF
--- a/main/auth/auth.py
+++ b/main/auth/auth.py
@@ -319,7 +319,7 @@ def save_request_params():
     }
 
 
-def signin_oauth(oauth_app, scheme='http'):
+def signin_oauth(oauth_app, scheme=None):
   try:
     flask.session.pop('oauth_token', None)
     save_request_params()

--- a/main/auth/bitbucket.py
+++ b/main/auth/bitbucket.py
@@ -22,7 +22,6 @@ bitbucket_config = dict(
 bitbucket = auth.create_oauth_app(bitbucket_config, 'bitbucket')
 
 
-@app.route('/_s/callback/bitbucket/oauth-authorized/')
 @app.route('/api/auth/callback/bitbucket/')
 def bitbucket_authorized():
   response = bitbucket.authorized_response()

--- a/main/auth/dropbox.py
+++ b/main/auth/dropbox.py
@@ -22,7 +22,6 @@ dropbox_config = dict(
 dropbox = auth.create_oauth_app(dropbox_config, 'dropbox')
 
 
-@app.route('/_s/callback/dropbox/oauth-authorized/')
 @app.route('/api/auth/callback/dropbox/')
 def dropbox_authorized():
   response = dropbox.authorized_response()

--- a/main/auth/facebook.py
+++ b/main/auth/facebook.py
@@ -22,7 +22,6 @@ facebook_config = dict(
 facebook = auth.create_oauth_app(facebook_config, 'facebook')
 
 
-@app.route('/_s/callback/facebook/oauth-authorized/')
 @app.route('/api/auth/callback/facebook/')
 def facebook_authorized():
   response = facebook.authorized_response()

--- a/main/auth/gae.py
+++ b/main/auth/gae.py
@@ -19,7 +19,6 @@ def signin_gae():
   return flask.redirect(gae_url)
 
 
-@app.route('/_s/callback/gae/authorized/')
 @app.route('/api/auth/callback/gae/')
 def gae_authorized():
   gae_user = users.get_current_user()

--- a/main/auth/github.py
+++ b/main/auth/github.py
@@ -23,7 +23,6 @@ github_config = dict(
 github = auth.create_oauth_app(github_config, 'github')
 
 
-@app.route('/_s/callback/github/oauth-authorized/')
 @app.route('/api/auth/callback/github/')
 def github_authorized():
   response = github.authorized_response()

--- a/main/auth/google.py
+++ b/main/auth/google.py
@@ -23,7 +23,6 @@ google_config = dict(
 google = auth.create_oauth_app(google_config, 'google')
 
 
-@app.route('/_s/callback/google/oauth-authorized/')
 @app.route('/api/auth/callback/google/')
 def google_authorized():
   response = google.authorized_response()

--- a/main/auth/instagram.py
+++ b/main/auth/instagram.py
@@ -21,7 +21,6 @@ instagram_config = dict(
 instagram = auth.create_oauth_app(instagram_config, 'instagram')
 
 
-@app.route('/_s/callback/instagram/oauth-authorized/')
 @app.route('/api/auth/callback/instagram/')
 def instagram_authorized():
   response = instagram.authorized_response()

--- a/main/auth/linkedin.py
+++ b/main/auth/linkedin.py
@@ -34,7 +34,6 @@ def change_linkedin_query(uri, headers, body):
 linkedin.pre_request = change_linkedin_query
 
 
-@app.route('/_s/callback/linkedin/oauth-authorized/')
 @app.route('/api/auth/callback/linkedin/')
 def linkedin_authorized():
   response = linkedin.authorized_response()

--- a/main/auth/microsoft.py
+++ b/main/auth/microsoft.py
@@ -23,7 +23,6 @@ microsoft_config = dict(
 microsoft = auth.create_oauth_app(microsoft_config, 'microsoft')
 
 
-@app.route('/_s/callback/microsoft/oauth-authorized/')
 @app.route('/api/auth/callback/microsoft/')
 def microsoft_authorized():
   response = microsoft.authorized_response()

--- a/main/auth/reddit.py
+++ b/main/auth/reddit.py
@@ -60,7 +60,6 @@ def reddit_handle_oauth2_response():
 reddit.handle_oauth2_response = reddit_handle_oauth2_response
 
 
-@app.route('/_s/callback/reddit/oauth-authorized/')
 @app.route('/api/auth/callback/reddit/')
 def reddit_authorized():
   response = reddit.authorized_response()

--- a/main/auth/reddit.py
+++ b/main/auth/reddit.py
@@ -81,7 +81,7 @@ def get_reddit_oauth_token():
 
 @app.route('/signin/reddit/')
 def signin_reddit():
-  return auth.signin_oauth(reddit, flask.request.scheme)
+  return auth.signin_oauth(reddit)
 
 
 def retrieve_user_from_reddit(response):

--- a/main/auth/twitter.py
+++ b/main/auth/twitter.py
@@ -22,7 +22,6 @@ twitter_config = dict(
 twitter = auth.create_oauth_app(twitter_config, 'twitter')
 
 
-@app.route('/_s/callback/twitter/oauth-authorized/')
 @app.route('/api/auth/callback/twitter/')
 def twitter_authorized():
   response = twitter.authorized_response()

--- a/main/auth/vk.py
+++ b/main/auth/vk.py
@@ -21,7 +21,6 @@ vk_config = dict(
 vk = auth.create_oauth_app(vk_config, 'vk')
 
 
-@app.route('/_s/callback/vk/oauth-authorized/')
 @app.route('/api/auth/callback/vk/')
 def vk_authorized():
   response = vk.authorized_response()

--- a/main/auth/yahoo.py
+++ b/main/auth/yahoo.py
@@ -21,7 +21,6 @@ yahoo_config = dict(
 yahoo = auth.create_oauth_app(yahoo_config, 'yahoo')
 
 
-@app.route('/_s/callback/yahoo/oauth-authorized/')
 @app.route('/api/auth/callback/yahoo/')
 def yahoo_authorized():
   response = yahoo.authorized_response()


### PR DESCRIPTION
It was added because of Dropbox that asks only for HTTPS (which is a good thing) but it breaks other stuff when the default is `http`. Had the same problem with Google and others.. it should be OK with this change