### PR TITLE
Removed source maps from ext libraries.

### DIFF
--- a/gulp/tasks/ext.coffee
+++ b/gulp/tasks/ext.coffee
@@ -17,7 +17,5 @@ gulp.task 'ext', false, ->
 gulp.task 'ext:dev', false, ->
   gulp.src config.ext
   .pipe $.plumber errorHandler: util.onError
-  .pipe do $.sourcemaps.init
   .pipe $.concat 'ext.js'
-  .pipe do $.sourcemaps.write
   .pipe gulp.dest "#{paths.static.dev}/script"


### PR DESCRIPTION
Source maps for libs caused great delay when developing.