### PR TITLE
Reloading only when the necessary files has build.

### DIFF
--- a/gulp/tasks/watch.coffee
+++ b/gulp/tasks/watch.coffee
@@ -6,8 +6,8 @@ paths = require '../paths'
 gulp.task 'reload', false, ->
   do $.livereload.listen
   gulp.watch([
-    "#{paths.static.root}/**/*.css"
-    "#{paths.static.root}/**/*.js"
+    "#{paths.static.root}/dev/style/*.css"
+    "#{paths.static.root}/dev/script/*.js"
     "#{paths.main}/**/*.html"
     "#{paths.main}/**/*.py"
   ]).on 'change', $.livereload.changed

--- a/main/__init__.py
+++ b/main/__init__.py
@@ -13,4 +13,4 @@ License MIT, see LICENSE for more details.
 
 """
 
-__version__ = '3.1.1'
+__version__ = '3.2.0'


### PR DESCRIPTION
The files that should trigger the reload when changed are not the whole, static folder but the dev folder in it.