### PR TITLE
Fix mimetype for .woff2 fonts

### DIFF
--- a/main/app.yaml
+++ b/main/app.yaml
@@ -34,6 +34,12 @@ handlers:
   mime_type: font/ttf
   expiration: 1000d
 
+- url: /p/(.*\.woff2)
+  static_files: static/\1
+  upload: static/(.*\.woff2)
+  mime_type: font/woff2
+  expiration: 1000d
+
 - url: /p/
   static_dir: static/
   expiration: 1000d


### PR DESCRIPTION
W3C [recommends](http://www.w3.org/TR/WOFF2/#IMT) ```font/woff2``` for WOFF 2.0 fonts.