### PR TITLE
Middleware wrapper for appstats

### DIFF
--- a/main/appengine_config.py
+++ b/main/appengine_config.py
@@ -14,3 +14,9 @@ else:
   stubs.FakeFile._skip_files = re_
   sys.path.insert(0, 'lib')
 sys.path.insert(0, 'libx')
+
+
+def webapp_add_wsgi_middleware(app):
+  from google.appengine.ext.appstats import recording
+  app = recording.appstats_wsgi_middleware(app)
+  return app


### PR DESCRIPTION
I noticed today that appstats don't work any longer. You can verify by visiting /_ah/stats, despite the fact they are enabled in app.yaml we need this request wrapper.