### PR TITLE
Disable PIN security for werkzeug >= v0.11

### DIFF
--- a/main/main.py
+++ b/main/main.py
@@ -29,5 +29,10 @@ import api.v1
 
 if config.DEVELOPMENT:
   from werkzeug import debug
-  app.wsgi_app = debug.DebuggedApplication(app.wsgi_app, evalex=True)
+  try:
+    app.wsgi_app = debug.DebuggedApplication(
+        app.wsgi_app, evalex=True, pin_security=False,
+      )
+  except TypeError:
+    app.wsgi_app = debug.DebuggedApplication(app.wsgi_app, evalex=True)
   app.testing = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ flask-oauthlib==0.9.2
 flask-restful==0.3.5
 flask-wtf==0.12
 unidecode==0.4.18
-werkzeug==0.10.4


### PR DESCRIPTION
Disable [PIN protection](http://werkzeug.pocoo.org/docs/0.11/debug/#debugger-pin) for new versions of Werkzeug, because it conflicts with GAE sandbox environment (```os.getuid()``` returns an incorrect user id). Final fix #446