### PR TITLE
Improved api.auth.signing username/email handling

### DIFF
--- a/main/api/v1/auth.py
+++ b/main/api/v1/auth.py
@@ -23,15 +23,14 @@ class AuthAPI(restful.Resource):
       'email': wf.Str(missing=None),
       'password': wf.Str(missing=None),
     })
-    username = args['username'] or args['email']
+    handler = args['username'] or args['email']
     password = args['password']
-    if not username or not password:
+    if not handler or not password:
       return flask.abort(400)
 
-    if username.find('@') > 0:
-      user_db = model.User.get_by('email', username.lower())
-    else:
-      user_db = model.User.get_by('username', username.lower())
+    user_db = model.User.get_by(
+      'email' if '@' in handler else 'username', handler.lower()
+    )
 
     if user_db and user_db.password_hash == util.password_hash(user_db, password):
       auth.signin_user_db(user_db)


### PR DESCRIPTION
Changed the `username.find('@') > 0` to a `'@' in username` construct, which according to http://stackoverflow.com/a/18437825 is more readable (and less important: faster).

Also, it looked to me that if somehow I have a username with an '@' inside, and provide that as credentials to the `api.auth.signing` end-point, the routine would not find me... thinking that because of the `@` it must be an email address; which if different from my username w/`@` wouldn't be found; and then assuming that there is nothing more to check. I fixed this by allowing the routine to check it as an email, and if it finds it... okay; but if it didn't find a match, it will still check it as a username (and find me).

A further improvement could of course be to actually consider the given arguments and handle these directly, rather then funnelling both username and email through this lookup/check.