### PR TITLE
Added pageres screenshots to the tests

### DIFF
--- a/main/control/test.py
+++ b/main/control/test.py
@@ -10,6 +10,7 @@ import util
 from main import app
 
 TESTS = [
+  'pageres',
   'responsive',
   'grid',
   'heading',

--- a/main/templates/admin/test/test_pageres.html
+++ b/main/templates/admin/test/test_pageres.html
@@ -1,0 +1,30 @@
+<h3>Requirements</h3>
+
+<pre class="code">
+  npm install -g pageres-cli
+</pre>
+
+
+<h3>Run the followings in your terminal</h3>
+
+# set resolutions = [
+  '360x640',
+  '375x667',
+  '414x736',
+  '435x773',
+  '800x600',
+  '1024x768',
+  '1280x1024',
+]
+
+# set routes = [
+  'welcome',
+  'feedback',
+  'signin',
+]
+
+<pre class="code small">
+# for route in routes
+pageres {{url_for(route, _external=True)}} {{' '.join(resolutions)}} --filename='{{route}} <%= size %> - <%= url %>'
+# endfor
+</pre>


### PR DESCRIPTION
It generates something like this:
<img width="937" alt="screen shot 2016-02-03 at 12 22 48" src="https://cloud.githubusercontent.com/assets/125676/12780863/e8c1c9fa-ca70-11e5-9eff-b04b04fedbaa.png">

Test it yourself asfter installing `pageres-cli`:

```bash
npm install -g pageres-cli
```

```bash
pageres https://gae-init.com/ 360x640 375x667 414x736 435x773 800x600 1024x768 1280x1024 --filename='welcome <%= size %> - <%= url %>'
pageres https://gae-init.com/feedback/ 360x640 375x667 414x736 435x773 800x600 1024x768 1280x1024 --filename='feedback <%= size %> - <%= url %>'
pageres https://gae-init.com/signin/ 360x640 375x667 414x736 435x773 800x600 1024x768 1280x1024 --filename='signin <%= size %> - <%= url %>'
```