### PR TITLE
Using Microsoft Application Registration portal

### DIFF
--- a/main/templates/admin/bit/microsoft_oauth.html
+++ b/main/templates/admin/bit/microsoft_oauth.html
@@ -3,7 +3,7 @@
       'Microsoft',
       (form.microsoft_client_id, form.microsoft_client_secret),
       '''
-        Redirect domain for <a href="https://account.live.com/developers/applications" target="_blank">Microsoft Accounts</a>:
+        Redirect domain for <a href="https://apps.dev.microsoft.com/#/appList" target="_blank">Microsoft Application Registration</a>:
         <em>%s</em>
       ''' % url_for('microsoft_authorized', _external=True)
     )


### PR DESCRIPTION
Using Microsoft Application Registration portal instead of (broken) Microsoft Account Developer Center in the Auth Config, based on answer http://stackoverflow.com/a/35683183/2315612 (to my question http://stackoverflow.com/q/35536331/2315612), as I experienced issues uploading a logo with my App.

The new link also allows the user to change language much easier, so I indeed think this is the better site to use.