### PR TITLE
Fixed issue with empty name in GitHub user response

### DIFF
--- a/main/auth/github.py
+++ b/main/auth/github.py
@@ -48,9 +48,9 @@ def retrieve_user_from_github(response):
   auth_id = 'github_%s' % str(response['id'])
   user_db = model.User.get_by('auth_ids', auth_id)
   return user_db or auth.create_user_db(
-    auth_id,
-    response.get('name', response.get('login')),
-    response.get('login'),
-    response.get('email', ''),
+    auth_id=auth_id,
+    name=response['name'] or response['login'],
+    username=response['login'],
+    email=response.get('email', ''),
     verified=bool(response.get('email', '')),
   )


### PR DESCRIPTION
GitHub allows an empty Name in a user profile, which causes issues when such a user registers for the first time with gae-init; as the "name" in the response will be None. This was despite the fact that the "login" of the response was the default/fall-back when getting the "name" of the response.

This PR fixes this with an explicit `or`, such that we will either get the "name" or the "login" of the GitHub response and we can thus handle users with an empty Name in their profile.