### PR TITLE
Fix for zindex values being changed by gulp-cssnano by default

### DIFF
--- a/gulp/tasks/style.coffee
+++ b/gulp/tasks/style.coffee
@@ -11,6 +11,7 @@ gulp.task 'style', false, ->
   .pipe do $.less
   .pipe $.cssnano
     discardComments: removeAll: true
+    zindex: false
   .pipe $.size {title: 'Minified styles'}
   .pipe gulp.dest "#{paths.static.min}/style"
 


### PR DESCRIPTION
Fixes issue #493 to prevent z-index values in css files to automatically be changed by gulp-cssnano