### PR TITLE
Updated Bitbucket to OAuth2

### DIFF
--- a/main/auth/bitbucket.py
+++ b/main/auth/bitbucket.py
@@ -10,12 +10,12 @@ import util
 from main import app
 
 bitbucket_config = dict(
-  access_token_url='https://bitbucket.org/api/1.0/oauth/access_token',
-  authorize_url='https://bitbucket.org/api/1.0/oauth/authenticate',
-  base_url='https://api.bitbucket.org/1.0/',
+  access_token_method='POST',
+  access_token_url='https://bitbucket.org/site/oauth2/access_token',
+  authorize_url='https://bitbucket.org/site/oauth2/authorize',
+  base_url='https://api.bitbucket.org/2.0/',
   consumer_key=config.CONFIG_DB.bitbucket_key,
   consumer_secret=config.CONFIG_DB.bitbucket_secret,
-  request_token_url='https://bitbucket.org/api/1.0/oauth/request_token',
 )
 
 bitbucket = auth.create_oauth_app(bitbucket_config, 'bitbucket')
@@ -28,12 +28,9 @@ def bitbucket_authorized():
     flask.flash('You denied the request to sign in.')
     return flask.redirect(util.get_next_url())
 
-  flask.session['oauth_token'] = (
-    response['oauth_token'],
-    response['oauth_token_secret'],
-  )
+  flask.session['oauth_token'] = (response['access_token'], '')
   me = bitbucket.get('user')
-  user_db = retrieve_user_from_bitbucket(me.data['user'])
+  user_db = retrieve_user_from_bitbucket(me.data)
   return auth.signin_user_db(user_db)
 
 
@@ -52,15 +49,11 @@ def retrieve_user_from_bitbucket(response):
   user_db = model.User.get_by('auth_ids', auth_id)
   if user_db:
     return user_db
-  if response['first_name'] or response['last_name']:
-    name = ' '.join((response['first_name'], response['last_name'])).strip()
-  else:
-    name = response['username']
-  emails = bitbucket.get('users/%s/emails' % response['username'])
-  email = ''.join([e['email'] for e in emails.data if e['primary']][0:1])
+  emails = bitbucket.get('user/emails').data['values']
+  email = ''.join([e['email'] for e in emails if e['is_primary']][0:1])
   return auth.create_user_db(
     auth_id=auth_id,
-    name=name,
+    name=response['display_name'],
     username=response['username'],
     email=email,
     verified=bool(email),

--- a/main/templates/admin/bit/bitbucket_oauth.html
+++ b/main/templates/admin/bit/bitbucket_oauth.html
@@ -2,5 +2,8 @@
   forms.panel_fields(
       'Bitbucket',
       (form.bitbucket_key, form.bitbucket_secret),
+      '''
+        Callback URL for Bitbucket: <em>%s</em> (needs Email and Read permissions for Account)
+      ''' % url_for('bitbucket_authorized', _external=True)
     )
 }}


### PR DESCRIPTION
Updated Bitbucket to OAuth2 interface, see https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html (and previous attempt in #417).

On the OAuth tab of the Bitbucket settings (of your profile there), you can configure "OAuth consumers". Provide a "Callback URL" to use the OAuth2 interface (this PR includes the link on the Auth Config part for Bitbucket); and set the Email and Read permissions for Account.

Note that there is **no** `request_token_params={'scope': 'account'}` being used; as Bitbucket noted:

> Scopes are defined on the client/consumer instance. Bitbucket Cloud does not currently support the use of the optional scope parameter on the individual grant requests.


_Background for this PR:_ I noticed that using the OAuth1 interface, I needed to set much more permissions (also Read on Team membership and Read on Repositories) for no good reason other than to make it work (such that gae-init allows a new user to register using Bitbucket).