### PR TITLE
More explicit expiration settings for static resources

### DIFF
--- a/main/app.yaml
+++ b/main/app.yaml
@@ -34,17 +34,17 @@ handlers:
   static_files: static/\1
   upload: static/(.*\.ttf)
   mime_type: font/ttf
-  expiration: 1000d
+  expiration: "365d"
 
 - url: /p/(.*\.woff2)
   static_files: static/\1
   upload: static/(.*\.woff2)
   mime_type: font/woff2
-  expiration: 1000d
+  expiration: "365d"
 
 - url: /p/
   static_dir: static/
-  expiration: 1000d
+  expiration: "365d"
 
 - url: /.*
   script: main.app


### PR DESCRIPTION
Addresses #382 by setting the expiration of static resources with `expiration: "365d"` in the `app.yaml` file.

Note that `favicon.ico` and `robots.txt` have not been set, they may get the defaults (which unless set is expected to be 10 minutes). Caching `robots.txt` doesn't make sense, as this is typically collected by robotic crawlers/indexers only; so no real browser with caching involved anyway. While expiration of `favicon.ico` could be set, it makes sense to delay that until gae-init derived projects have settled on one. Read: most projects will experiment a while with the gae-init default `main/static/img/favicon.ico` resource before changing it. Having a higher expiration default might actually make it harder for projects to get their favicon updated, which is already notoriously hard for most browsers (as they deal with favicons in a different way than with other resources; at least that is how I understand it).