### PR TITLE
Fixed callback URL for Facebook

### DIFF
--- a/main/templates/admin/bit/facebook_oauth.html
+++ b/main/templates/admin/bit/facebook_oauth.html
@@ -5,6 +5,6 @@
       '''
         Site URL for <a href="https://developers.facebook.com/apps" target="_blank">Facebook application</a>:
         <em>%s</em>
-      ''' % request.host_url[:-1]
+      ''' % url_for('facebook_authorized', _external=True)
     )
 }}


### PR DESCRIPTION
Fixed callback URL for Facebook, to be used when configuring your App on the Facebook for Developers site, under the "Valid OAuth redirect URIs" of the "Client OAuth Settings" section.