### PR TITLE
Change fontawesome icon for 'Versions' link

### DIFF
--- a/main/templates/admin/admin.html
+++ b/main/templates/admin/admin.html
@@ -33,7 +33,7 @@
     {{admin_link('Dashboard', 'tachometer', 'https://console.cloud.google.com/home/dashboard?project=%s' % config.APPLICATION_ID, 'gae')}}
     {{admin_link('Datastore', 'database', 'https://console.cloud.google.com/datastore/query?project=%s' % config.APPLICATION_ID, 'gae')}}
     {{admin_link('Instances', 'bolt', 'https://console.cloud.google.com/appengine/instances?project=%s' % config.APPLICATION_ID, 'gae')}}
-    {{admin_link('Versions', 'archive', 'https://console.cloud.google.com/appengine/versions?project=%s' % config.APPLICATION_ID, 'gae')}}
+    {{admin_link('Versions', 'history', 'https://console.cloud.google.com/appengine/versions?project=%s' % config.APPLICATION_ID, 'gae')}}
     {{admin_link('Logs', 'bullhorn', 'https://console.cloud.google.com/logs?project=%s&amp;versionId=%s' % (config.APPLICATION_ID, config.CURRENT_VERSION_NAME), 'gae')}}
     {{admin_link('APIs', 'wrench', 'https://console.developers.google.com/apis/library?project=%s' % config.APPLICATION_ID, 'gae')}}
     {{admin_link('Settings', 'cogs', 'https://console.cloud.google.com/settings?project=%s' % config.APPLICATION_ID, 'gae')}}


### PR DESCRIPTION
gcloud console icon looks as:
<img width="215" alt="screen shot 2016-06-16 at 02 55 23" src="https://cloud.githubusercontent.com/assets/47926/16101466/1092d6a8-3377-11e6-8668-90faf3f1bd2c.png">