### PR TITLE
Fixed jumping to top in filter test

### DIFF
--- a/main/templates/admin/test/test_filter.html
+++ b/main/templates/admin/test/test_filter.html
@@ -8,7 +8,7 @@
       {{utils.filter_by_link('limit', 64, hash=test)}}
       {{utils.filter_by_link('limit', 128, hash=test)}}
       {{utils.filter_by_link('limit', 512, hash=test)}}
-      {{utils.filter_by_link('limit', -1, label='&infin;')}}
+      {{utils.filter_by_link('limit', -1, hash=test, label='&infin;')}}
     </div>
 
     <div class="btn-group btn-group-sm">


### PR DESCRIPTION
Fixed jumping to top in filter test: when selecting the unlimited / -1 option there was no #filter in the URI, thus making the page jump to the top.