### PR TITLE
Fixed test pagination

### DIFF
--- a/main/templates/admin/test/test_pagination.html
+++ b/main/templates/admin/test/test_pagination.html
@@ -2,9 +2,7 @@
 
 <div class="row">
   <div class="col-xs-4">
-    <h2>
-      {{utils.back_link('Back to pagination', 'admin_test', test='pagination')}}
-    </h2>
+    {{utils.next_link(prev_url='#%s' % test, prev_caption='Previous Page')}}
   </div>
   <div class="col-xs-4">
     {{utils.next_link('#%s' % test)}}


### PR DESCRIPTION
There was a broken backlink in the Pagination part of the Test page, replaced it with an example of providing a custom caption previous page link.