### PR TITLE
Fixed test page test section hover links

### DIFF
--- a/main/templates/admin/test/test.html
+++ b/main/templates/admin/test/test.html
@@ -24,7 +24,7 @@
         <a class="pull-right" href="#" title="Back to top"><span class="text-muted fa fa-angle-up fa-fw"></span></a>
         <a href="#{{test}}">{{test.title()}}</a>
         <small class="on-hover">
-          <a href="{{url_for('admin_test', test=test)}}" title="Just this test"><span class="fa fa-link fa-fw"></span></a>
+          <a href="#" title="Back to top"><span class="fa fa-link fa-fw"></span></a>
         </small>
       </h2>
       # include 'admin/test/test_%s.html' % test


### PR DESCRIPTION
The on-hover "Just this test" links next to the title of test sections on the test page didn't work (anymore) and caused 500 errors; fixed by changing them to "Back to top" on-hover links.