### PR TITLE
Remove "preview" from gcloud deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 .git*
 .hg*
+.idea
 bower_components
 main/index.yaml
 main/lib

--- a/gulp/tasks/build.coffee
+++ b/gulp/tasks/build.coffee
@@ -28,7 +28,7 @@ gulp.task 'deploy', 'Deploy project to Google App Engine.', ['build'], ->
 
   gulp.src('run.py').pipe $.start [{
     match: /run.py$/
-    cmd: "gcloud preview app deploy main/*.yaml#{options_str}"
+    cmd: "gcloud app deploy main/*.yaml#{options_str}"
   }]
 
 


### PR DESCRIPTION
From https://cloud.google.com/sdk/release_notes

The gcloud app surface is now available in the GA and beta release tracks. Please use gcloud app instead of gcloud preview app (some features only available in the beta release track).