### PR TITLE
Make redirects to HTTPS 301 instead of 302

### DIFF
--- a/main/app.yaml
+++ b/main/app.yaml
@@ -47,6 +47,7 @@ handlers:
 - url: /.*
   script: main.app
   secure: always
+  redirect_http_response_code: 301
 
 skip_files:
 - ^(.*/)?#.*#


### PR DESCRIPTION
It's best practice to use a 301 redirect when directing users from HTTP to HTTPS:

https://support.google.com/webmasters/answer/6033086?hl=en&ref_topic=6033084
https://support.google.com/webmasters/answer/93633
