### PR TITLE
jQuery 3 and gulp-uglify 2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "bootstrap": "~3",
     "font-awesome": "~4",
-    "jquery": "~2",
+    "jquery": "~3",
     "moment": "~2"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-size": "~2",
     "gulp-sourcemaps": "~1",
     "gulp-start": "~1",
-    "gulp-uglify": "~1",
+    "gulp-uglify": "~2",
     "gulp-util": "~3",
     "gulp-zip": "~3",
     "less": "~2",


### PR DESCRIPTION
Even though there is a tendency to stop using jQuery I think we have to upgrade it and since Bootstrap 3.3.7 is supporting it should be fine.. :) if anyone has issues with it could always have a specific version anyway..