### PR TITLE
Make historical starting date inclusive

### DIFF
--- a/main/auth/auth.py
+++ b/main/auth/auth.py
@@ -397,6 +397,7 @@ def create_user_db(auth_id, name, username, email='', verified=False, **props):
   )
   user_db.put()
   task.new_user_notification(user_db)
+  task.task_calculate_stats(user_db.created)
   return user_db
 
 

--- a/main/cron.yaml
+++ b/main/cron.yaml
@@ -1,0 +1,4 @@
+cron:
+- description: yesterday
+  url: /admin/stats/calc/yesterday/
+  schedule: every day 01:00

--- a/main/model/__init__.py
+++ b/main/model/__init__.py
@@ -3,4 +3,5 @@
 from .base import Base
 from .config_auth import ConfigAuth
 from .config import Config
+from .stats import Stats
 from .user import User

--- a/main/model/stats.py
+++ b/main/model/stats.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+
+from google.appengine.ext import ndb
+
+from api import fields
+import model
+import util
+
+
+class Stats(model.Base):
+  timestamp = ndb.DateProperty(required=True)
+  duration = ndb.StringProperty(default='day', required=True, choices=['day', 'week', 'month', 'year'])
+  users = ndb.IntegerProperty(default=0)
+  status = ndb.StringProperty(default='dirty', required=True, choices=['dirty', 'synced', 'syncing'])
+
+  FIELDS = {
+    'timestamp': fields.DateTime,
+    'duration': fields.String,
+    'users': fields.Integer,
+    'status': fields.String,
+  }
+
+  FIELDS.update(model.Base.FIELDS)

--- a/main/static/src/style/admin.less
+++ b/main/static/src/style/admin.less
@@ -1,0 +1,6 @@
+.admin-chart {
+  .img-thumbnail;
+  margin: @line-height-computed 0;
+  height: 512px;
+  width: 100%;
+}

--- a/main/static/src/style/style.less
+++ b/main/static/src/style/style.less
@@ -3,6 +3,7 @@
 
 @import "base";
 @import "variables";
+@import "admin";
 @import "test";
 @import "mixins";
 @import "footer";

--- a/main/task.py
+++ b/main/task.py
@@ -163,7 +163,7 @@ def email_conflict_notification(email):
 ###############################################################################
 def task_calculate_stats(timestamp, duration='day'):
   if duration == 'day' and timestamp < datetime.utcnow():
-    if timestamp > datetime(2012, 1, 1):
+    if timestamp >= datetime(2012, 1, 1):
       deferred.defer(calculate_stats, timestamp, duration)
 
 

--- a/main/task.py
+++ b/main/task.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 
 import logging
+from datetime import datetime
 
 import flask
 from google.appengine.api import mail
 from google.appengine.ext import deferred
 
 import config
+import model
 import util
 
 
@@ -154,3 +156,59 @@ def email_conflict_notification(email):
     flask.url_for('user_list', email=email, _external=True),
   )
   send_mail_notification('Conflict with: %s' % email, body)
+
+
+###############################################################################
+# Stats Related
+###############################################################################
+def task_calculate_stats(timestamp, duration='day'):
+  if duration == 'day' and timestamp < datetime.utcnow():
+    if timestamp > datetime(2012, 1, 1):
+      deferred.defer(calculate_stats, timestamp, duration)
+
+
+def calculate_stats(timestamp, duration='day'):
+  if duration not in ['day', 'week', 'month', 'year']:
+    return
+
+  start, finish = util.date_limits(timestamp, duration)
+  code = util.date_code(timestamp, duration)
+
+  stats_db = model.Stats.get_or_insert(
+    code,
+    parent=config.CONFIG_DB.key,
+    timestamp=start,
+    duration=duration,
+    status='syncing',
+  )
+  stats_db.status = 'syncing'
+  stats_db.put()
+
+  if duration == 'day':
+    user_qry = model.User.query()
+    user_qry = user_qry.filter(model.User.created >= start)
+    user_qry = user_qry.filter(model.User.created < finish)
+    stats_db.users = user_qry.count()
+  else:
+    stats_qry = model.Stats.query()
+    stats_qry = stats_qry.filter(model.Stats.timestamp >= start)
+    stats_qry = stats_qry.filter(model.Stats.timestamp < finish)
+    if duration == 'year':
+      stats_qry = stats_qry.filter(model.Stats.duration == 'month')
+    else:
+      stats_qry = stats_qry.filter(model.Stats.duration == 'day')
+    stats_dbs = stats_qry.fetch()
+
+    stats_db.users = 0
+    for s_db in stats_dbs:
+      stats_db.users += s_db.users
+
+  stats_db.status = 'synced' if finish < datetime.utcnow() else 'dirty'
+  stats_db.put()
+
+  if duration == 'day':
+    deferred.defer(calculate_stats, start, 'week')
+  elif duration == 'week':
+    deferred.defer(calculate_stats, start, 'month')
+  elif duration == 'month':
+    deferred.defer(calculate_stats, start, 'year')

--- a/main/templates/admin/admin.html
+++ b/main/templates/admin/admin.html
@@ -9,6 +9,7 @@
     {{admin_link('App Config', 'cog', url_for('admin_config'))}}
     {{admin_link('Auth Config', 'lock', url_for('admin_auth'))}}
     {{admin_link('Test', 'sliders', url_for('admin_test'))}}
+    {{admin_link('Stats', 'line-chart', url_for('admin_stats'))}}
   </div>
 
   <div class="page-header">

--- a/main/templates/admin/stats.html
+++ b/main/templates/admin/stats.html
@@ -1,0 +1,98 @@
+# extends 'admin/admin_base.html'
+# import 'macro/forms.html' as forms
+# import 'macro/utils.html' as utils
+
+
+# block admin_content
+  <div class="row">
+    <div class="col-sm-offset-2 col-sm-8">
+      <ul class="nav nav-pills nav-justified">
+        <li class="{{'active' if 'stats-day' in html_class}}"><a href="{{url_for('admin_stats', duration='day')}}">Day</a></li>
+        <li class="{{'active' if 'stats-week' in html_class}}"><a href="{{url_for('admin_stats', duration='week')}}">Week</a></li>
+        <li class="{{'active' if 'stats-month' in html_class}}"><a href="{{url_for('admin_stats', duration='month')}}">Month</a></li>
+        <li class="{{'active' if 'stats-year' in html_class}}"><a href="{{url_for('admin_stats', duration='year')}}">Year</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <hr class="{{'hide' if stats_dbs|count > 1}}">
+
+  <div class="alert alert-warning {{'hide' if stats_dbs|count > 0}}">
+    There are no stats for this duration. Calculate <a href="{{url_for('admin_stats_calc', redirect=true)}}">now</a>.
+  </div>
+
+  <div class="admin-chart {{'hide' if stats_dbs|count < 2}}" id="admin-chart"></div>
+
+  <div class="table-responsive {{'hide' if stats_dbs|count == 0}}">
+    <table class="table table-striped table-bordered table-condensed table-hover">
+      <thead>
+        <tr>
+          <th class="col-xs-6 text-center">Timestamp</th>
+          <th class="col-xs-3 text-center">Users</th>
+          <th class="col-xs-3 text-center">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        # for stats_db in stats_dbs
+          <tr class="{{'success' if stats_db.status == 'synced' else 'warning'}}">
+            <td>
+              # if duration == 'day'
+                {{stats_db.timestamp.strftime('%d %b %Y (%A)')}}
+              # elif duration == 'week'
+                {{stats_db.timestamp.strftime('%d %b %Y (W%W)')}}
+              # elif duration == 'month'
+                {{stats_db.timestamp.strftime('%B %Y')}}
+              # elif duration == 'year'
+                {{stats_db.timestamp.strftime('%Y')}}
+              # endif
+            </td>
+            <td class="text-right">{{stats_db.users}}</td>
+            <td class="text-center">{{stats_db.status}}</td>
+          </tr>
+        # endfor
+      </tbody>
+    </table>
+  </div>
+# endblock
+
+# block scripts
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+  <script type="text/javascript">
+    google.charts.load('current', {'packages':['corechart']});
+    google.charts.setOnLoadCallback(drawChart);
+    function drawChart() {
+      var data = google.visualization.arrayToDataTable([
+        ['{{duration}}', 'Users'],
+        # for stats_db in stats_dbs | reverse
+          # if stats_db.status == 'synced'
+            # if duration in ['day', 'week']
+              # set label = stats_db.timestamp.strftime('%d %b %y')
+            # elif duration == 'month'
+              # set label = stats_db.timestamp.strftime('%b %y')
+            # elif duration == 'year'
+              # set label = stats_db.timestamp.strftime('%Y')
+            # endif
+            ['{{label}}',  {{stats_db.users}}],
+          # endif
+        # endfor
+      ]);
+
+      var options = {
+        chartArea: {width: '90%', height: '80%'},
+        vAxis: {minValue: 0},
+        legend: {position: 'bottom'}
+      };
+
+      # if stats_dbs | length > 2
+        var chart = new google.visualization.AreaChart(document.getElementById('admin-chart'));
+      # else
+        var chart = new google.visualization.ColumnChart(document.getElementById('admin-chart'));
+      # endif
+      chart.draw(data, options);
+
+      $(window).resize(function(){
+        chart.draw(data, options);
+      });
+    }
+  </script>
+# endblock

--- a/main/util.py
+++ b/main/util.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from datetime import datetime
+from datetime import timedelta
 from uuid import uuid4
 import hashlib
 import re
@@ -219,3 +221,41 @@ def parse_tags(tags, separator=None):
 strip_filter = lambda x: x.strip() if x else ''
 email_filter = lambda x: x.lower().strip() if x else ''
 sort_filter = lambda x: sorted(x) if x else []
+
+
+###############################################################################
+# Dates Utils
+###############################################################################
+def date_code(timestamp, duration='day', prefix=''):
+  if duration == 'week':
+    year, week, day = timestamp.isocalendar()
+    code = '%d-%02d' % (year, week)
+  elif duration == 'month':
+    code = '%d-%02d' % (timestamp.year, timestamp.month)
+  elif duration == 'year':
+    code = '%d' % (timestamp.year)
+  else:
+    code = '%d-%02d-%02d' % (timestamp.year, timestamp.month, timestamp.day)
+
+  if prefix:
+    return '%s-%s-%s' % (prefix, duration, code)
+  return '%s-%s' % (duration, code)
+
+
+def date_limits(timestamp, duration='day'):
+  if duration == 'week':
+    delta = timedelta(days=timestamp.isoweekday() - 1)
+    start = datetime(timestamp.year, timestamp.month, timestamp.day) - delta
+    finish = start + timedelta(days=7)
+  elif duration == 'month':
+    start = datetime(timestamp.year, timestamp.month, 1)
+    year = start.year + (1 if start.month == 12 else 0)
+    month = (timestamp.month + 12) % 12 + 1
+    finish = datetime(year, month, 1)
+  elif duration == 'year':
+    start = datetime(timestamp.year, 1, 1)
+    finish = datetime(start.year + 1, 1, 1)
+  else:
+    start = datetime(timestamp.year, timestamp.month, timestamp.day)
+    finish = start + timedelta(days=1)
+  return (start, finish)


### PR DESCRIPTION
The historical starting date of 2012-01-01 should be included to avoid not having statistics for that date... Proposing to change (even if you did only party that day, or sleeping; or whatever) as others implementing stats should by default include such a historical/theoretical starting date; which they should probably set (close) to their launch date.