### PR TITLE
Removed spaces and leading zero

### DIFF
--- a/main/static/src/style/signin.less
+++ b/main/static/src/style/signin.less
@@ -19,7 +19,7 @@
     line-height: (@height-base + 2);
     font-size: 1.6em;
     text-align: center;
-    border-right: 1px solid rgba(0, 0, 0, 0.2);
+    border-right: 1px solid rgba(0,0,0,.2);
   }
   &.btn-lg {
     padding-left: @height-lg + @padding-large-horizontal;


### PR DESCRIPTION
In accordance with http://codeguide.co/#css-syntax guidance:

> Don't include spaces after commas _within_ rgb(), rgba(), hsl(), hsla(), or rect() values. This helps differentiate multiple color values (comma, no space) from multiple property values (comma with space).

> Don't prefix property values or color parameters with a leading zero (e.g., .5 instead of 0.5 and -.5px instead of -0.5px).