### PR TITLE
Renamed flask_wtf.Form to .FlaskForm

### DIFF
--- a/main/auth/auth.py
+++ b/main/auth/auth.py
@@ -181,7 +181,7 @@ def permission_required(permission=None, methods=None):
 ###############################################################################
 # Sign in stuff
 ###############################################################################
-class SignInForm(flask_wtf.Form):
+class SignInForm(flask_wtf.FlaskForm):
   email = wtforms.StringField(
     'Email',
     [wtforms.validators.required()],
@@ -235,7 +235,7 @@ def signin():
 ###############################################################################
 # Sign up stuff
 ###############################################################################
-class SignUpForm(flask_wtf.Form):
+class SignUpForm(flask_wtf.FlaskForm):
   email = wtforms.StringField(
     'Email',
     [wtforms.validators.required(), wtforms.validators.email()],

--- a/main/control/admin.py
+++ b/main/control/admin.py
@@ -38,7 +38,7 @@ def admin():
 ###############################################################################
 # Config Stuff
 ###############################################################################
-class ConfigUpdateForm(flask_wtf.Form):
+class ConfigUpdateForm(flask_wtf.FlaskForm):
   analytics_id = wtforms.StringField(model.Config.analytics_id._verbose_name, filters=[util.strip_filter])
   announcement_html = wtforms.TextAreaField(model.Config.announcement_html._verbose_name, filters=[util.strip_filter])
   announcement_type = wtforms.SelectField(model.Config.announcement_type._verbose_name, choices=[(t, t.title()) for t in model.Config.announcement_type._choices])
@@ -85,7 +85,7 @@ def admin_config():
 ###############################################################################
 # Auth Stuff
 ###############################################################################
-class AuthUpdateForm(flask_wtf.Form):
+class AuthUpdateForm(flask_wtf.FlaskForm):
   bitbucket_key = wtforms.StringField(model.Config.bitbucket_key._verbose_name, filters=[util.strip_filter])
   bitbucket_secret = wtforms.StringField(model.Config.bitbucket_secret._verbose_name, filters=[util.strip_filter])
   dropbox_app_key = wtforms.StringField(model.Config.dropbox_app_key._verbose_name, filters=[util.strip_filter])

--- a/main/control/feedback.py
+++ b/main/control/feedback.py
@@ -12,7 +12,7 @@ import util
 from main import app
 
 
-class FeedbackForm(flask_wtf.Form):
+class FeedbackForm(flask_wtf.FlaskForm):
   message = wtforms.TextAreaField(
     'Message',
     [wtforms.validators.required()], filters=[util.strip_filter],

--- a/main/control/profile.py
+++ b/main/control/profile.py
@@ -32,7 +32,7 @@ def profile():
 ###############################################################################
 # Profile Update
 ###############################################################################
-class ProfileUpdateForm(flask_wtf.Form):
+class ProfileUpdateForm(flask_wtf.FlaskForm):
   name = wtforms.StringField(
     model.User.name._verbose_name,
     [wtforms.validators.required()], filters=[util.strip_filter],
@@ -76,7 +76,7 @@ def profile_update():
 ###############################################################################
 # Profile Password
 ###############################################################################
-class ProfilePasswordForm(flask_wtf.Form):
+class ProfilePasswordForm(flask_wtf.FlaskForm):
   old_password = wtforms.StringField(
     'Old Password', [wtforms.validators.required()],
   )

--- a/main/control/test.py
+++ b/main/control/test.py
@@ -28,7 +28,7 @@ TESTS = [
 ]
 
 
-class TestForm(flask_wtf.Form):
+class TestForm(flask_wtf.FlaskForm):
   name = wtforms.StringField(
     'Text',
     [wtforms.validators.required()], filters=[util.strip_filter],

--- a/main/control/user.py
+++ b/main/control/user.py
@@ -50,7 +50,7 @@ def user_list():
 ###############################################################################
 # User Update
 ###############################################################################
-class UserUpdateForm(flask_wtf.Form):
+class UserUpdateForm(flask_wtf.FlaskForm):
   username = wtforms.StringField(
     model.User.username._verbose_name,
     [wtforms.validators.required(), wtforms.validators.length(min=2)],
@@ -146,7 +146,7 @@ def user_verify(token):
 ###############################################################################
 # User Forgot
 ###############################################################################
-class UserForgotForm(flask_wtf.Form):
+class UserForgotForm(flask_wtf.FlaskForm):
   email = wtforms.StringField(
     'Email',
     [wtforms.validators.required(), wtforms.validators.email()],
@@ -195,7 +195,7 @@ def user_forgot(token=None):
 ###############################################################################
 # User Reset
 ###############################################################################
-class UserResetForm(flask_wtf.Form):
+class UserResetForm(flask_wtf.FlaskForm):
   new_password = wtforms.StringField(
     'New Password',
     [wtforms.validators.required(), wtforms.validators.length(min=6)],
@@ -235,7 +235,7 @@ def user_reset(token=None):
 ###############################################################################
 # User Activate
 ###############################################################################
-class UserActivateForm(flask_wtf.Form):
+class UserActivateForm(flask_wtf.FlaskForm):
   name = wtforms.StringField(
     model.User.name._verbose_name,
     [wtforms.validators.required()], filters=[util.strip_filter],
@@ -278,7 +278,7 @@ def user_activate(token):
 ###############################################################################
 # User Merge
 ###############################################################################
-class UserMergeForm(flask_wtf.Form):
+class UserMergeForm(flask_wtf.FlaskForm):
   user_key = wtforms.StringField('User Key', [wtforms.validators.required()])
   user_keys = wtforms.StringField('User Keys', [wtforms.validators.required()])
   username = wtforms.StringField('Username', [wtforms.validators.optional()])


### PR DESCRIPTION
This is to addresses the following deprecation warning from Flask-WTF as seen in the logs:

> FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.