### PR TITLE
Refactored email verified and token approach

### DIFF
--- a/main/auth/auth.py
+++ b/main/auth/auth.py
@@ -367,10 +367,10 @@ def form_with_recaptcha(form):
 ###############################################################################
 # User related stuff
 ###############################################################################
-def create_user_db(auth_id, name, username, email='', verified=False, **props):
+def create_user_db(auth_id, name, username, email='', email_verified=False, **props):
   email = email.lower() if email else ''
-  if verified and email:
-    user_dbs, cursors = model.User.get_dbs(email=email, verified=True, limit=2)
+  if email_verified and email:
+    user_dbs, cursors = model.User.get_dbs(email=email, email_verified=True, limit=2)
     if len(user_dbs) == 1:
       user_db = user_dbs[0]
       user_db.auth_ids.append(auth_id)
@@ -391,10 +391,10 @@ def create_user_db(auth_id, name, username, email='', verified=False, **props):
   user_db = model.User(
     name=name,
     email=email,
+    email_token=util.uuid(),
+    email_verified=email_verified,
     username=new_username,
     auth_ids=[auth_id] if auth_id else [],
-    verified=verified,
-    token=util.uuid(),
     **props
   )
   user_db.put()

--- a/main/auth/azure_ad.py
+++ b/main/auth/azure_ad.py
@@ -64,5 +64,5 @@ def retrieve_user_from_azure_ad(response):
     name='%s %s' % (first_name, last_name),
     username=email or username,
     email=email,
-    verified=bool(email),
+    email_verified=bool(email),
   )

--- a/main/auth/bitbucket.py
+++ b/main/auth/bitbucket.py
@@ -56,5 +56,5 @@ def retrieve_user_from_bitbucket(response):
     name=response['display_name'],
     username=response['username'],
     email=email,
-    verified=bool(email),
+    email_verified=bool(email),
   )

--- a/main/auth/dropbox.py
+++ b/main/auth/dropbox.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 dropbox_config = dict(
   access_token_method='POST',
   access_token_url='https://api.dropbox.com/1/oauth2/token',

--- a/main/auth/facebook.py
+++ b/main/auth/facebook.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 facebook_config = dict(
   access_token_url='/oauth/access_token',
   authorize_url='/oauth/authorize',
@@ -52,5 +53,5 @@ def retrieve_user_from_facebook(response):
     name=response['name'],
     username=response.get('username', response['name']),
     email=response.get('email', ''),
-    verified=bool(response.get('email', '')),
+    email_verified=bool(response.get('email', '')),
   )

--- a/main/auth/gae.py
+++ b/main/auth/gae.py
@@ -44,6 +44,6 @@ def retrieve_user_from_gae(gae_user):
     name=util.create_name_from_email(gae_user.email()),
     username=gae_user.email(),
     email=gae_user.email(),
-    verified=True,
+    email_verified=True,
     admin=users.is_current_user_admin(),
   )

--- a/main/auth/github.py
+++ b/main/auth/github.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 github_config = dict(
   access_token_method='POST',
   access_token_url='https://github.com/login/oauth/access_token',
@@ -52,5 +53,5 @@ def retrieve_user_from_github(response):
     name=response['name'] or response['login'],
     username=response['login'],
     email=response.get('email', ''),
-    verified=bool(response.get('email', '')),
+    email_verified=bool(response.get('email', '')),
   )

--- a/main/auth/google.py
+++ b/main/auth/google.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 google_config = dict(
   access_token_method='POST',
   access_token_url='https://accounts.google.com/o/oauth2/token',
@@ -73,5 +74,5 @@ def retrieve_user_from_google(response):
     name=name,
     username=email or name,
     email=email,
-    verified=bool(email),
+    email_verified=bool(email),
   )

--- a/main/auth/instagram.py
+++ b/main/auth/instagram.py
@@ -8,6 +8,7 @@ import util
 
 from main import app
 
+
 instagram_config = dict(
   access_token_method='POST',
   access_token_url='https://api.instagram.com/oauth/access_token',

--- a/main/auth/linkedin.py
+++ b/main/auth/linkedin.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 linkedin_config = dict(
   access_token_method='POST',
   access_token_url='https://www.linkedin.com/uas/oauth2/accessToken',
@@ -70,5 +71,5 @@ def retrieve_user_from_linkedin(response):
     name=name,
     username=email or name,
     email=email,
-    verified=bool(email),
+    email_verified=bool(email),
   )

--- a/main/auth/mailru.py
+++ b/main/auth/mailru.py
@@ -11,6 +11,7 @@ import util
 
 from main import app
 
+
 mailru_config = dict(
   access_token_url='https://connect.mail.ru/oauth/token',
   authorize_url='https://connect.mail.ru/oauth/authorize',
@@ -73,5 +74,5 @@ def retrieve_user_from_mailru(response):
     name=name or email,
     username=email or name,
     email=email,
-    verified=bool(email),
+    email_verified=bool(email),
   )

--- a/main/auth/microsoft.py
+++ b/main/auth/microsoft.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 microsoft_config = dict(
   access_token_method='POST',
   access_token_url='https://login.live.com/oauth20_token.srf',
@@ -60,5 +61,5 @@ def retrieve_user_from_microsoft(response):
     name=response.get('name', ''),
     username=email,
     email=email,
-    verified=bool(email),
+    email_verified=bool(email),
   )

--- a/main/auth/reddit.py
+++ b/main/auth/reddit.py
@@ -13,6 +13,7 @@ import util
 
 from main import app
 
+
 reddit_config = dict(
   access_token_method='POST',
   access_token_params={'grant_type': 'authorization_code'},

--- a/main/auth/twitter.py
+++ b/main/auth/twitter.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 twitter_config = dict(
   access_token_url='https://api.twitter.com/oauth/access_token',
   authorize_url='https://api.twitter.com/oauth/authorize',

--- a/main/auth/vk.py
+++ b/main/auth/vk.py
@@ -9,6 +9,7 @@ import util
 
 from main import app
 
+
 vk_config = dict(
   access_token_url='https://oauth.vk.com/access_token',
   authorize_url='https://oauth.vk.com/authorize',

--- a/main/auth/yahoo.py
+++ b/main/auth/yahoo.py
@@ -8,6 +8,7 @@ import util
 
 from main import app
 
+
 yahoo_config = dict(
   access_token_url='https://api.login.yahoo.com/oauth/v2/get_token',
   authorize_url='https://api.login.yahoo.com/oauth/v2/request_auth',
@@ -73,5 +74,5 @@ def retrieve_user_from_yahoo(response):
     name=' '.join(names).strip() or response['nickname'],
     username=response['nickname'],
     email=email,
-    verified=bool(email),
+    email_verified=bool(email),
   )

--- a/main/control/user.py
+++ b/main/control/user.py
@@ -67,7 +67,7 @@ class UserUpdateForm(flask_wtf.FlaskForm):
   )
   admin = wtforms.BooleanField(model.User.admin._verbose_name)
   active = wtforms.BooleanField(model.User.active._verbose_name)
-  verified = wtforms.BooleanField(model.User.verified._verbose_name)
+  email_verified = wtforms.BooleanField(model.User.email_verified._verbose_name)
   permissions = wtforms.SelectMultipleField(
     model.User.permissions._verbose_name,
     filters=[util.sort_filter],

--- a/main/model/user.py
+++ b/main/model/user.py
@@ -18,12 +18,12 @@ class User(model.Base):
   name = ndb.StringProperty(required=True)
   username = ndb.StringProperty(required=True)
   email = ndb.StringProperty(default='')
+  email_verified = ndb.BooleanProperty(default=False)
+  email_token = ndb.StringProperty(default='')
   auth_ids = ndb.StringProperty(repeated=True)
   active = ndb.BooleanProperty(default=True)
   admin = ndb.BooleanProperty(default=False)
   permissions = ndb.StringProperty(repeated=True)
-  verified = ndb.BooleanProperty(default=False)
-  token = ndb.StringProperty(default='')
   password_hash = ndb.StringProperty(default='')
 
   def has_permission(self, perm):
@@ -40,18 +40,18 @@ class User(model.Base):
 
   @classmethod
   def get_dbs(
-    cls, admin=None, active=None, verified=None, permissions=None, **kwargs
+    cls, admin=None, active=None, email_verified=None, permissions=None, **kwargs
   ):
     args = parser.parse({
       'admin': wf.Bool(missing=None),
       'active': wf.Bool(missing=None),
-      'verified': wf.Bool(missing=None),
+      'email_verified': wf.Bool(missing=None),
       'permissions': wf.DelimitedList(wf.Str(), delimiter=',', missing=[]),
     })
     return super(User, cls).get_dbs(
       admin=admin or args['admin'],
       active=active or args['active'],
-      verified=verified or args['verified'],
+      email_verified=email_verified or args['email_verified'],
       permissions=permissions or args['permissions'],
       **kwargs
     )
@@ -68,7 +68,7 @@ class User(model.Base):
     if not config.CONFIG_DB.check_unique_email:
       return True
     user_keys, _ = util.get_keys(
-      cls.query(), email=email, verified=True, limit=2,
+      cls.query(), email=email, email_verified=True, limit=2,
     )
     return not user_keys or self_key in user_keys and not user_keys[1:]
 
@@ -78,10 +78,10 @@ class User(model.Base):
     'auth_ids': fields.List(fields.String),
     'avatar_url': fields.String,
     'email': fields.String,
+    'email_verified': fields.Boolean,
     'name': fields.String,
     'permissions': fields.List(fields.String),
     'username': fields.String,
-    'verified': fields.Boolean,
   }
 
   FIELDS.update(model.Base.FIELDS)

--- a/main/task.py
+++ b/main/task.py
@@ -50,9 +50,9 @@ def new_user_notification(user_db):
 # User Related
 ###############################################################################
 def verify_email_notification(user_db):
-  if not (config.CONFIG_DB.verify_email and user_db.email) or user_db.verified:
+  if not (config.CONFIG_DB.verify_email and user_db.email) or user_db.email_verified:
     return
-  user_db.token = util.uuid()
+  user_db.email_token = util.uuid()
   user_db.put()
 
   to = '%s <%s>' % (user_db.name, user_db.email)
@@ -71,7 +71,7 @@ Best regards,
 %(brand)s
 ''' % {
     'name': user_db.name,
-    'link': flask.url_for('user_verify', token=user_db.token, _external=True),
+    'link': flask.url_for('user_verify', email_token=user_db.email_token, _external=True),
     'brand': config.CONFIG_DB.brand_name,
   }
 
@@ -85,7 +85,7 @@ Best regards,
 def reset_password_notification(user_db):
   if not user_db.email:
     return
-  user_db.token = util.uuid()
+  user_db.email_token = util.uuid()
   user_db.put()
 
   to = '%s <%s>' % (user_db.name, user_db.email)
@@ -104,7 +104,7 @@ Best regards,
 %(brand)s
 ''' % {
     'name': user_db.name,
-    'link': flask.url_for('user_reset', token=user_db.token, _external=True),
+    'link': flask.url_for('user_reset', email_token=user_db.email_token, _external=True),
     'brand': config.CONFIG_DB.brand_name,
   }
 
@@ -118,7 +118,7 @@ Best regards,
 def activate_user_notification(user_db):
   if not user_db.email:
     return
-  user_db.token = util.uuid()
+  user_db.email_token = util.uuid()
   user_db.put()
 
   to = user_db.email
@@ -134,7 +134,7 @@ so we can take a look.
 Best regards,
 %(brand)s
 ''' % {
-    'link': flask.url_for('user_activate', token=user_db.token, _external=True),
+    'link': flask.url_for('user_activate', email_token=user_db.email_token, _external=True),
     'brand': config.CONFIG_DB.brand_name,
   }
 

--- a/main/templates/user/user_email_field.html
+++ b/main/templates/user/user_email_field.html
@@ -6,7 +6,7 @@
     {{forms.field_optional(form.email)}}
     {{form.email(class='form-control')}}
     # if request.method == 'GET' and user_db.email
-      # if user_db.verified
+      # if user_db.email_verified
         <span class="fa fa-check form-control-feedback text-success" title="This email is verified"></span>
       # else
         <span class="fa fa-warning form-control-feedback text-warning" title="This email is not verified"></span>

--- a/main/templates/user/user_list.html
+++ b/main/templates/user/user_list.html
@@ -29,8 +29,8 @@
 
       <div class="btn-group btn-group-sm">
         <button type="button" class="btn btn-success" disabled>Verified</button>
-        {{utils.filter_by_link('verified', True, 'thumbs-o-up')}}
-        {{utils.filter_by_link('verified', False, 'thumbs-o-down')}}
+        {{utils.filter_by_link('email_verified', True, 'thumbs-o-up')}}
+        {{utils.filter_by_link('email_verified', False, 'thumbs-o-down')}}
       </div>
 
       <div class="btn-group btn-group-sm">
@@ -110,7 +110,7 @@
             </td>
             <td class="text-nowrap">
               {{user_db.email}}
-              # if user_db.email and user_db.verified
+              # if user_db.email and user_db.email_verified
                 <span class="fa fa-check text-success" title="Verified"></span>
               # endif
               <br>

--- a/main/templates/user/user_update.html
+++ b/main/templates/user/user_update.html
@@ -19,7 +19,7 @@
         {{forms.text_field(form.name, autofocus=True)}}
         {{forms.text_field(form.username, autocomplete='off')}}
         # include 'user/user_email_field.html'
-        {{forms.checkbox_field(form.verified)}}
+        {{forms.checkbox_field(form.email_verified)}}
         # if current_user.user_db.key != user_db.key
           {{forms.checkbox_field(form.admin)}}
           {{forms.checkbox_field(form.active)}}


### PR DESCRIPTION
Removed ambiguity about `verified` and `token` by making it explicit; using `email_verified` and `email_token` to make clear that these are about email.

This should make it easier for users of gae-init to integrate other attributes that could use verification, like SMS based tokens when verifying a mobile phone number.