### PR TITLE
Reorder paths to use the latest packages from lib/*

### DIFF
--- a/main/path_util.py
+++ b/main/path_util.py
@@ -10,7 +10,7 @@ def path_package_path(deps_path, shadow_pkgs):
   for _, pkg, ispkg in pkgutil.iter_modules():
     if ispkg and pkg in shadow_pkgs:
       global_pkg = __import__(pkg)
-      global_pkg.__path__.append('%s/%s' % (deps_path, pkg))
+      global_pkg.__path__.insert(0, '%s/%s' % (deps_path, pkg))
 
 
 def is_shadowing(package_name):


### PR DESCRIPTION
abdf915303d3f3891adb0c3d8c4b73a377cb57cc has led to the use of outdated `werkzeug` package from `google-cloud-sdk` instead `lib/werkzeug`.