### PR TITLE
Resolve error on dev server with certain system packages installed

### DIFF
--- a/main/path_util.py
+++ b/main/path_util.py
@@ -44,7 +44,7 @@ def get_shadows_dir(dirname):
   if not os.path.exists(dirname):
     return shadow_pkgs
   for pkg in os.listdir(dirname):
-    if not os.path.isfile(pkg) and is_shadowing(pkg):
+    if not pkg=='__init__.py' and os.path.isfile(pkg) and is_shadowing(pkg):
       shadow_pkgs.add(pkg)
   return shadow_pkgs
 

--- a/main/path_util.py
+++ b/main/path_util.py
@@ -44,7 +44,7 @@ def get_shadows_dir(dirname):
   if not os.path.exists(dirname):
     return shadow_pkgs
   for pkg in os.listdir(dirname):
-    if not pkg=='__init__.py' and os.path.isfile(pkg) and is_shadowing(pkg):
+    if not pkg == '__init__.py' and os.path.isfile(pkg) and is_shadowing(pkg):
       shadow_pkgs.add(pkg)
   return shadow_pkgs
 


### PR DESCRIPTION
I had been encountering this error:
```
Traceback (most recent call last):
  File "/Users/russ/google-cloud-sdk/platform/google_appengine/google/appengine/runtime/wsgi.py", line 240, in Handle
    handler = _config_handle.add_wsgi_middleware(self._LoadHandler())
  File "/Users/russ/google-cloud-sdk/platform/google_appengine/google/appengine/api/lib_config.py", line 351, in __getattr__
    self._update_configs()
  File "/Users/russ/google-cloud-sdk/platform/google_appengine/google/appengine/api/lib_config.py", line 287, in _update_configs
    self._registry.initialize()
  File "/Users/russ/google-cloud-sdk/platform/google_appengine/google/appengine/api/lib_config.py", line 160, in initialize
    import_func(self._modname)
  File "/Users/russ/gae-init-project/main/appengine_config.py", line 24, in <module>
    sys_path_insert('libx')
  File "/Users/russ/gae-init-project/main/path_util.py", line 59, in sys_path_insert
    path_package_path(dirname, get_shadows_dir(dirname))
  File "/Users/russ/gae-init-project/main/path_util.py", line 50, in get_shadows_dir
    if not pkg=='__init__' and not os.path.isfile(pkg) and is_shadowing(pkg):
  File "/Users/russ/gae-init-project/main/path_util.py", line 18, in is_shadowing
    __import__(os.path.splitext(package_name)[0])
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/PIL/__init__.py", line 14, in <module>
    from . import version
ValueError: Attempted relative import in non-package
```