### PR TITLE
Updated proseWrap setting to use never

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,7 +1,7 @@
 bracketSpacing: false
 jsxBracketSameLine: false
 printWidth: 80
-proseWrap: false
+proseWrap: never
 requirePragma: false
 semi: true
 singleQuote: true


### PR DESCRIPTION
The ``proseWrap: false`` in .prettierrc.yaml actually defaults to ``proseWrap: never`` and thus this PR makes that explicit.