### PR TITLE
Workaround for bug in babel/uglify usage in script.coffee

### DIFF
--- a/gulp/tasks/script.coffee
+++ b/gulp/tasks/script.coffee
@@ -14,8 +14,8 @@ gulp.task 'script', false, ->
   .pipe $.plumber errorHandler: util.onError
   .pipe $.if is_coffee, $.coffee()
   .pipe $.concat 'script.js'
-  .pipe $.babel presets: ['es2015']
-  .pipe $.uglify()
+  #.pipe $.babel presets: ['es2015']
+  #.pipe $.uglify()
   .pipe $.size {title: 'Minified scripts'}
   .pipe gulp.dest "#{paths.static.min}/script"
 


### PR DESCRIPTION
In adding support for Babel (in #770), a subtle bug was introduced in the `gulp build` target. It caused the production (minified) version of `script.js` to receive a leading `"use strict";` clause. Which in turn produced errors on the browser console like `ext.js?20180108t144620.406792256148446707:1 jQuery.Deferred exception: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them TypeError: 'caller'` and preventing users to click on list items (on Admin based List views of models for example, such as the User List); normally used for selecting their details view.

This workaround is a quick fix, causing the `script.js` to be un-minimized / un-obfuscated.