### PR TITLE
Doc update: change global install of gulp to gulp-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ gulp
 To install [Gulp][] as a global package:
 
 ```bash
-npm install -g gulp
+npm install --global gulp-cli
 ```
 
 ## Deploying on Google App Engine

--- a/bin/requirements_linux.sh
+++ b/bin/requirements_linux.sh
@@ -8,7 +8,7 @@ gcloud components install app-engine-python
 sudo apt-get install nodejs
 
 # Gulp.js
-sudo npm install -g gulp
+npm install --global gulp-cli
 
 # Python related
 curl https://bootstrap.pypa.io/get-pip.py | sudo python

--- a/bin/requirements_osx_brew.sh
+++ b/bin/requirements_osx_brew.sh
@@ -8,7 +8,7 @@ gcloud components install app-engine-python
 brew install node
 
 # Gulp.js
-npm install -g gulp
+npm install --global gulp-cli
 
 # Python related
 curl https://bootstrap.pypa.io/get-pip.py | python

--- a/bin/requirements_osx_port.sh
+++ b/bin/requirements_osx_port.sh
@@ -8,7 +8,7 @@ gcloud components install app-engine-python
 sudo port install nodejs
 
 # Gulp.js
-npm install -g gulp
+npm install --global gulp-cli
 
 # Python related
 curl https://bootstrap.pypa.io/get-pip.py | python


### PR DESCRIPTION
This follows the current instructions at:
https://gulpjs.org/getting-started