### PR TITLE
Add `gulp deploy --dryrun` to test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - gcloud components install app-engine-python
 
 before_script:
-  - npm install -g gulp-cli
+  - npm install --global gulp-cli
   
 script: 
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,10 @@ before_install:
   - source /home/travis/google-cloud-sdk/path.bash.inc
   - gcloud version
   - gcloud components install app-engine-python
+
+before_script:
+  - npm install -g gulp-cli
+  
+script: 
+  - yarn test
+  - gulp deploy --dryrun


### PR DESCRIPTION
Previously our travis script checked only that dependencies were installable, and that the linting tools passed (yarn test).

This will check that the scripts run to enable the project to be deployed to Google Cloud.