### PR TITLE
Update requirements in Pageres section of Test page

### DIFF
--- a/main/templates/admin/test/test_pageres.html
+++ b/main/templates/admin/test/test_pageres.html
@@ -1,7 +1,7 @@
 <h3>Requirements</h3>
 
 <pre class="code">
-  npm install -g pageres-cli
+  yarn global add pageres-cli
 </pre>
 
 


### PR DESCRIPTION
Fixes #983 Update requirements in Pageres section of Test page, by using {{yarn}} instead of {{npm}} as the project has moved to using the Yarn package manager.