### PR TITLE
Removed adding import dev_appserver and fix_sys_path call to gae.pth

### DIFF
--- a/run.py
+++ b/run.py
@@ -126,10 +126,6 @@ def create_virtualenv():
     echo_to = 'echo %s >> {pth}'.format(pth=pth_file)
     os.system(echo_to % find_gae_path())
     os.system(echo_to % os.path.abspath(DIR_LIBX))
-    fix_path_cmd = 'import dev_appserver; dev_appserver.fix_sys_path()'
-    os.system(echo_to % (
-      fix_path_cmd if IS_WINDOWS else '"%s"' % fix_path_cmd
-    ))
   return True
 
 


### PR DESCRIPTION
This fixes #962 and #1011 by removing the addition of "`import dev_appserver; dev_appserver.fix_sys_path()`" to the `gae.pth` file in the `site-packages` folder of the virtual environment.

As noted in #962, there are comments with https://issuetracker.google.com/issues/117145272 suggesting that the Google AppEngine (GAE) SDK 219+ has received changes that caused issues with that `import dev_appserver; dev_appserver.fix_sys_path()` approach. As noted in #962 and #1011, the problem shows when doing a clean install `yarn` or using a `gulp reset` and `yarn` sequence.

In my case, with a Xubuntu virtual machine with 1 CPU and 2 GB RAM, the `yarn` could take about 5-6 minutes and sometimes crashed; consuming lots of memory and swap space while having above a thousand processes (observed with SDK 225, but similar experiences with SDK 219 to 222). With this fix, tested with SDK 218 and SDK 225, the `yarn` takes less than 40 seconds (doesn't swap and shows less than 250 processes and less than 60% memory use; even at peak).