### PR TITLE
Show module versions on test page

### DIFF
--- a/main/app.yaml
+++ b/main/app.yaml
@@ -13,6 +13,9 @@ inbound_services:
   - warmup
 
 libraries:
+  - name: setuptools
+    version: latest
+
   - name: ssl
     version: latest
 

--- a/main/control/test.py
+++ b/main/control/test.py
@@ -6,8 +6,10 @@ import wtforms
 
 import auth
 import util
+import versions
 
 from main import app
+
 
 TESTS = [
   'alert',
@@ -25,6 +27,7 @@ TESTS = [
   'responsive',
   'social',
   'table',
+  'versions',
 ]
 
 
@@ -95,5 +98,6 @@ def admin_test(test=None):
     form=form,
     test=test,
     tests=TESTS,
+    versions=versions.get_versions(),
     back_url_for='admin_test' if test else None,
   )

--- a/main/control/versions.py
+++ b/main/control/versions.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+
+import importlib
+import pkg_resources
+
+
+MODULES = [
+  'blinker',
+  'flask',
+  'flask-login|flask_login',
+  'flask-oauthlib|flask_oauthlib',
+  'flask-restful|flask_restful.__version__',
+  'flask-wtf|flask_wtf',
+  'jinja2',
+  'pyjwt|jwt',
+  'unidecode',
+  'webargs',
+]
+
+
+def get_module_version(spec):
+  names = spec.split('|', 1)
+  try:
+    module = importlib.import_module(names[-1])
+  except:
+    return (names[0], 'ERROR: Cannot import')
+  try:
+    version = module.__version__
+  except:
+    version = 'n/a'
+  return (names[0], version)
+
+
+def get_versions(working_set=True):
+  versions = [get_module_version(name) for name in MODULES]
+  if working_set:
+    for pkg in pkg_resources.working_set:
+      name, version = str(pkg).split(' ', 1)
+      versions.append(('{} *'.format(name), version))
+  versions.sort()
+  return versions

--- a/main/templates/admin/test/test_versions.html
+++ b/main/templates/admin/test/test_versions.html
@@ -1,9 +1,9 @@
 <p>
   Modules and their versions, '*' indicates those in the active working set.
-  <div class="alert alert-warning {{'hide' if versions}}">
-    No data on versions
-  </div>
 </p>
+<div class="alert alert-warning {{'hide' if versions}}">
+  No data on versions
+</div>
 <table class="table table-striped table-bordered table-hover {{'hide' if not versions}}">
   <thead>
     <tr>

--- a/main/templates/admin/test/test_versions.html
+++ b/main/templates/admin/test/test_versions.html
@@ -1,0 +1,22 @@
+<p>
+  Modules and their versions, '*' indicates those in the active working set.
+  <div class="alert alert-warning {{'hide' if versions}}">
+    No data on versions
+  </div>
+</p>
+<table class="table table-striped table-bordered table-hover {{'hide' if not versions}}">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Version</th>
+    </tr>
+  </thead>
+  <tbody>
+    # for version in versions
+      <tr>
+        <td>{{version[0]}}</td>
+        <td>{{version[1]}}</td>
+      </tr>
+    # endfor
+  </tbody>
+</table>

--- a/run.py
+++ b/run.py
@@ -176,10 +176,8 @@ def install_py_libs():
 
   exclude_ext = ['.pth', '.pyc', '.egg-info', '.dist-info', '.so']
   exclude_prefix = ['setuptools-', 'pip-', 'Pillow-']
-  exclude = [
-    'test', 'tests', 'pip', 'setuptools', '_markerlib', 'PIL',
-    'easy_install.py', 'pkg_resources', 'pkg_resources.py'
-  ]
+  exclude = ['test', 'tests', 'pip', 'setuptools', '_markerlib', 'PIL',
+             'easy_install.py']
 
   def _exclude_prefix(pkg):
     for prefix in exclude_prefix:

--- a/run.py
+++ b/run.py
@@ -176,8 +176,7 @@ def install_py_libs():
 
   exclude_ext = ['.pth', '.pyc', '.egg-info', '.dist-info', '.so']
   exclude_prefix = ['setuptools-', 'pip-', 'Pillow-']
-  exclude = ['test', 'tests', 'pip', 'setuptools', '_markerlib', 'PIL',
-             'easy_install.py']
+  exclude = ['test', 'tests', 'pip', 'setuptools', '_markerlib', 'PIL', 'easy_install.py']
 
   def _exclude_prefix(pkg):
     for prefix in exclude_prefix:


### PR DESCRIPTION
This PR adds a Versions test page, which will show versions of modules used in the project; including those in the so called working set. It is worth to note that it will show differences between local testing and when deployed online.

In order to do so, it includes the Google AppEngine (GAE) built-in `setuptools` (see `app.yaml`).

In the `install_py_libs()` method of `run.py` there is a further change to allow the `pkg_resources` (of `setuptools`) to be copied into the deployed project. This is thus kind of reverting #552, but I've found that this PR helps me fix issues seen when trying to use other third party libraries (such as bleach). Previously, to use bleach (for input scrubbing), I had to pin Jinja2 to the built-in version 2.6 and that in turn required me to pin Flask to version 0.12.4. In fact, debugging to show versions in that setup showed me that the GAE with such a pinned Flask/Jinja2 configuration was using a `setuptools` version 0.6c11 and I couldn't change it at all. Therefore, I tried different methods and found that this PR provided me the solution to change Flask/Jinja2 to the latest versions via the `requirements.txt` and being able to use the bleach third-party module without issues (as now it finds the `pkg_resources` it previously couldn't).

I recall that others also found difficulty with third-party libraries before, so I hope this can also help them resolve their issues. It probably helps to see which versions of modules are loaded in the deployed instance provided. You will need to configure which modules are shown in the `versions.py` source file.