### PR TITLE
Rollback support_datastore_emulator

### DIFF
--- a/run.py
+++ b/run.py
@@ -348,7 +348,6 @@ def run_start():
   run_command = ' '.join(map(str, [
     'dev_appserver.py',
     DIR_MAIN,
-    '--support_datastore_emulator=true',
     '--host %s' % ARGS.host,
     '--port %s' % port,
     '--admin_port %s' % (port + 1),


### PR DESCRIPTION
_ERROR: (dev_appserver) To use the Google Cloud Datastore emulator, a Java 8+ JRE must be installed and on your system PATH_

I think this is an unacceptable dependency for Python environment.