### PR TITLE
Added simplejson to fix #1056 (retry)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ flask-wtf==0.14.2
 flask==1.0.2
 jinja2==2.10
 pyjwt==1.7.1
+simplejson==3.16.0
 unidecode==1.0.23
 webargs==5.0.0


### PR DESCRIPTION
Retry of #1057 where I made a mistake somehow... so this is only adding simplejson to requirements in order to fix #1056 due to WebArgs 5.0.0 now needing simplejson for Python 2