### PR TITLE
Fix login via Twitter

### DIFF
--- a/main/auth/twitter.py
+++ b/main/auth/twitter.py
@@ -11,13 +11,15 @@ import util
 
 from main import app
 
+
 twitter_config = dict(
   access_token_url='https://api.twitter.com/oauth/access_token',
-  authorize_url='https://api.twitter.com/oauth/authorize',
+  authorize_url='https://api.twitter.com/oauth/authenticate',
   base_url='https://api.twitter.com/1.1/',
   consumer_key=config.CONFIG_DB.twitter_consumer_key,
   consumer_secret=config.CONFIG_DB.twitter_consumer_secret,
   request_token_url='https://api.twitter.com/oauth/request_token',
+  signature_method='HMAC-SHA1',
 )
 
 twitter = auth.create_oauth_app(twitter_config, 'twitter')

--- a/main/templates/admin/bit/twitter_oauth.html
+++ b/main/templates/admin/bit/twitter_oauth.html
@@ -4,7 +4,8 @@
     (form.twitter_consumer_key, form.twitter_consumer_secret),
     '''
       Callback URL for <a href="https://dev.twitter.com/apps" target="_blank">Twitter application</a>:
-      <em>%s</em>
+      <em>%s</em><br>
+      Enable the "Sign in with Twitter" option for the Twitter application.
     ''' % url_for('twitter_authorized', _external=True)
   )
 }}


### PR DESCRIPTION
Recently noticed that login via Twitter was no longer working (don't know when it broke), but checked the logs and it said something about `signature_method` missing (with a 500 response on the `gae-init` side). This PR fixes that by setting that `signature_method` to HMAC-SHA1.

The `authorize_url` endpoint was also changed as [the Twitter Developer documentation] (https://developer.twitter.com/en/docs/basics/authentication/api-reference/authenticate.html) says:

> This _(that is: the newly used GET oauth/authenticate)_ method differs from GET oauth/authorize _(method previously used)_ in that if the user has already granted the application permission, the redirect will occur without the user having to re-approve the application. To realize this behavior, you must enable the _Use Sign in with Twitter_ setting on your application record.

For which this PR also adds a reminder to enable that option