### PR TITLE
Fix login via Yahoo

### DIFF
--- a/main/auth/yahoo.py
+++ b/main/auth/yahoo.py
@@ -2,48 +2,79 @@
 
 from __future__ import absolute_import
 
+import base64
 import flask
 
+from flask_oauthlib import client
+from werkzeug import urls
+
 import auth
+import config
 import model
 import util
 
 from main import app
 
+
 yahoo_config = dict(
-  access_token_url='https://api.login.yahoo.com/oauth/v2/get_token',
-  authorize_url='https://api.login.yahoo.com/oauth/v2/request_auth',
-  base_url='https://query.yahooapis.com/',
-  consumer_key=model.Config.get_master_db().yahoo_consumer_key,
-  consumer_secret=model.Config.get_master_db().yahoo_consumer_secret,
-  request_token_url='https://api.login.yahoo.com/oauth/v2/get_request_token',
+  access_token_method='POST',
+  access_token_params={'grant_type': 'authorization_code'},
+  access_token_url='https://api.login.yahoo.com/oauth2/get_token',
+  authorize_url='https://api.login.yahoo.com/oauth2/request_auth',
+  base_url='https://social.yahooapis.com/v1/user/',
+  consumer_key=config.CONFIG_DB.yahoo_consumer_key,
+  consumer_secret=config.CONFIG_DB.yahoo_consumer_secret,
+  request_token_params={'state': util.uuid()},
 )
 
 yahoo = auth.create_oauth_app(yahoo_config, 'yahoo')
 
 
+def yahoo_handle_oauth2_response(args):
+  access_args = {
+    'code': args.get('code'),
+    'client_id': yahoo.consumer_key,
+    'client_secret': yahoo.consumer_secret,
+    'redirect_uri': flask.session.get('%s_oauthredir' % yahoo.name),
+    'state': args.get('state'),
+  }
+  access_args.update(yahoo.access_token_params)
+  auth_header = 'Basic %s' % base64.b64encode(
+    ('%s:%s' % (yahoo.consumer_key, yahoo.consumer_secret)).encode('latin1')
+  ).strip().decode('latin1')
+  response, content = yahoo.http_request(
+    yahoo.expand_url(yahoo.access_token_url),
+    method=yahoo.access_token_method,
+    data=urls.url_encode(access_args),
+    headers={
+      'Authorization': auth_header,
+      'User-Agent': config.USER_AGENT,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  )
+  data = client.parse_response(response, content)
+  if response.code not in (200, 201):
+    raise client.OAuthException(
+      'Invalid response from %s' % yahoo.name,
+      type='invalid_response', data=data,
+    )
+  return data
+
+
+yahoo.handle_oauth2_response = yahoo_handle_oauth2_response
+
+
 @app.route('/api/auth/callback/yahoo/')
 def yahoo_authorized():
   response = yahoo.authorized_response()
-  if response is None:
+  if response is None or flask.request.args.get('error'):
     flask.flash('You denied the request to sign in.')
     return flask.redirect(util.get_next_url())
 
-  flask.session['oauth_token'] = (
-    response['oauth_token'],
-    response['oauth_token_secret'],
-  )
-
-  fields = 'guid, emails, familyName, givenName, nickname'
-  me = yahoo.get(
-    '/v1/yql',
-    data={
-      'format': 'json',
-      'q': 'select %s from social.profile where guid = me;' % fields,
-      'realm': 'yahooapis.com',
-    },
-  )
-  user_db = retrieve_user_from_yahoo(me.data['query']['results']['profile'])
+  flask.session['oauth_token'] = (response['access_token'], '')
+  yahoo_guid = response['xoauth_yahoo_guid']
+  me = yahoo.get('%s/profile' % yahoo_guid, data={'format': 'json'})
+  user_db = retrieve_user_from_yahoo(me.data['profile'])
   return auth.signin_user_db(user_db)
 
 
@@ -63,17 +94,23 @@ def retrieve_user_from_yahoo(response):
   if user_db:
     return user_db
 
+  username = response.get('nickname', '').strip()
   names = [response.get('givenName', ''), response.get('familyName', '')]
+  name = ' '.join(names).strip() or username
+  if not name:
+    name = 'yahoo_user_%s' % response['guid']
+
   emails = response.get('emails', {})
   if not isinstance(emails, list):
     emails = [emails]
   emails = [e for e in emails if 'handle' in e]
   emails.sort(key=lambda e: e.get('primary', False))
   email = emails[0]['handle'] if emails else ''
+
   return auth.create_user_db(
     auth_id=auth_id,
-    name=' '.join(names).strip() or response['nickname'],
-    username=response['nickname'],
+    name=name,
+    username=username,
     email=email,
     verified=bool(email),
   )

--- a/main/templates/admin/bit/yahoo_oauth.html
+++ b/main/templates/admin/bit/yahoo_oauth.html
@@ -3,7 +3,7 @@
     'Yahoo!',
     (form.yahoo_consumer_key, form.yahoo_consumer_secret),
     '''
-      <a href="https://developer.apps.yahoo.com/projects" target="_blank">Yahoo! Projects</a>
+      Select the "Profiles (Social Directory)" permissions with "Read/Write Public and Private" option for your <a href="https://developer.yahoo.com/apps" target="_blank">Yahoo! Apps</a> to allow gathering of full name and email address.
     '''
   )
 }}


### PR DESCRIPTION
Recently noticed that login via Yahoo was no longer working (don't know when it broke), probably because the [Yahoo Query Language (YQL)](https://developer.yahoo.com/yql/) API has been retired:

> Important EOL Notice: As of Thursday, Jan. 3, 2019, the YQL service at query.yahooapis.com will be retired. This will impact users of datatables.org as well as developers who creates features using this YQL service.

Therefore, this PR aims to restore the login functionality using the Explicit Grant Flow described in the [Yahoo OAuth 2.0 Guide](https://developer.yahoo.com/oauth2/guide/) and basing the implementation a lot on our it is done for Reddit in `gae-init`. Now, I'm no OAuth expert, so I hope it is sufficient as-is.

I'm happy to report that we can still get full name and email addresses when users sign-up via Yahoo (which does require use of the "Profiles (Social Directory)" permissions with the "Read/Write Public and Private" access option. I've tried with only the "Read Public" access option, but then we only get the nickname (which can be used as username and full name, similar like we do for Twitter).

Note that I've not tried "Read/Write Public" to see if that would be sufficient; as far as I have ever used Yahoo in the past, I recall that the (now obsolete) YQL method also required "Profiles (Social Directory)" permissions with the "Read/Write Public and Private" access option.