### PR TITLE
Update bootstrap to v3.4.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.0",
     "font-awesome": "4.7.0",
     "jquery": "3.3.1",
     "moment": "2.23.0"


### PR DESCRIPTION
Update bootstrap to v3.4.0 in accordance with [a 13/12 release](https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/).