### PR TITLE
Rollback requests-oauthlib to 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ flask==1.0.2
 jinja2==2.10
 oauthlib==2.1.0
 pyjwt==1.7.1
-requests-oauthlib==1.2.0
+requests-oauthlib==1.1.0
 simplejson==3.16.0
 unidecode==1.0.23
 webargs==5.1.2


### PR DESCRIPTION
As noted in #1098 somehow the dependabot had already merged a change of requests-oauthlib to 1.2.0 in #1103 which is not correct, as it breaks stuff. It appears that in #1103 the dependabot should have been silenced on this subject, but the merge was probably done before that.