### PR TITLE
Pin the virtualenv to Python 2

### DIFF
--- a/run.py
+++ b/run.py
@@ -118,7 +118,7 @@ def site_packages_path():
 
 def create_virtualenv():
   if not os.path.exists(FILE_VENV):
-    os.system('virtualenv --no-site-packages %s' % DIR_VENV)
+    os.system('virtualenv --no-site-packages -p python2 %s' % DIR_VENV)
     os.system('echo %s >> %s' % (
       'set PYTHONPATH=' if IS_WINDOWS else 'unset PYTHONPATH', FILE_VENV
     ))


### PR DESCRIPTION
Pinning the virtualenv that is created in the `run.py` based `create_virtualenv()` method to Python 2. At least on my Linux Xubuntu 18.04 based development environment it fixed #1097. As the current target of gae-init is still the Google AppEngine Classic with Python 2.7 it makes sense to ensure the local build/run is pinned down to Python 2 as well.