### PR TITLE
Remove appstats (a Python 3 migration blocker)

### DIFF
--- a/main/appengine_config.py
+++ b/main/appengine_config.py
@@ -26,9 +26,3 @@ else:
   sys_path_insert('lib')
 
 sys_path_insert('libx')
-
-
-def webapp_add_wsgi_middleware(app):
-  from google.appengine.ext.appstats import recording
-  app = recording.appstats_wsgi_middleware(app)
-  return app


### PR DESCRIPTION
Not compatible with Python 3.7 GAE standard environment, and can mostly be achieved with stackdriver traces anyway.