### PR TITLE
Fix enum

### DIFF
--- a/main/app.yaml
+++ b/main/app.yaml
@@ -18,8 +18,6 @@ libraries:
 
   - name: ssl
     version: latest
-  - name: grpcio
-    version: 1.0.0
 
 error_handlers:
   - file: templates/error_static.html


### PR DESCRIPTION
Originally, I thought that adding `enum34` might resolve #1392, however some trial and error showed that I could get a local `gulp` run working by removing `grpcio` from `app.yaml` (at least while running an old SDK 247.0.0 to which I went back trying stuff...).