### PR TITLE
Removed obsolete virtualenv option

### DIFF
--- a/run.py
+++ b/run.py
@@ -118,7 +118,7 @@ def site_packages_path():
 
 def create_virtualenv():
   if not os.path.exists(FILE_VENV):
-    os.system('virtualenv --no-site-packages -p python2 %s' % DIR_VENV)
+    os.system('virtualenv -p python2 %s' % DIR_VENV)
     os.system('echo %s >> %s' % (
       'set PYTHONPATH=' if IS_WINDOWS else 'unset PYTHONPATH', FILE_VENV
     ))


### PR DESCRIPTION
Fixed #1409 by removing the obsolete virtualenv option `--no-site-packages` which (according to https://stackoverflow.com/a/60783839/2315612) has already been the default for multiple years.