### PR TITLE
Add wtforms[email] to requirements.txt - fixes #1430

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ simplejson==3.17.0
 unidecode==1.1.1
 webargs==5.5.3
 werkzeug==1.0.1
+wtforms[email]==2.3.1


### PR DESCRIPTION
wtforms is a requirement of flask-wtf, but we require the optional email extension.