### PR TITLE
Make error reporting more robust

### DIFF
--- a/main/api/helpers.py
+++ b/main/api/helpers.py
@@ -20,19 +20,14 @@ class Api(flask_restful.Api):
 
 def handle_error(e):
   logging.exception(e)
-  try:
-    e.code
-  except AttributeError:
-    e.code = 500
-    e.name = e.description = 'Internal Server Error'
   return util.jsonpify({
     'status': 'error',
-    'error_code': e.code,
-    'error_name': util.slugify(e.name),
-    'error_message': e.name,
+    'error_code': getattr(e, 'code', 500),
+    'error_name': util.slugify(getattr(e, 'name', 'Internal Server Error')),
+    'error_message': getattr(e, 'name', 'Internal Server Error'),
     'error_class': e.__class__.__name__,
-    'description': e.description,
-  }), e.code
+    'description': getattr(e, 'description', 'Internal Server Error'),
+  }), getattr(e, 'code', 500)
 
 
 def make_response(data, marshal_table, cursors=None):

--- a/main/control/error.py
+++ b/main/control/error.py
@@ -22,14 +22,10 @@ from main import app
 @app.errorhandler(422)  # Unprocessable Entity
 @app.errorhandler(500)  # Internal Server Error
 def error_handler(e):
-  try:
-    e.code
-  except AttributeError:
-    e.code = 500
-    e.name = 'Internal Server Error'
-
-  logging.error('%d - %s: %s', e.code, e.name, flask.request.url)
-  if e.code != 404:
+  code = getattr(e, 'code', 500)
+  error_name = getattr(e, 'name', 'Internal Server Error')
+  logging.error('%d - %s: %s', code, error_name, flask.request.url)
+  if code != 404:
     logging.exception(e)
 
   if flask.request.path.startswith('/api/'):
@@ -37,10 +33,10 @@ def error_handler(e):
 
   return flask.render_template(
     'error.html',
-    title='Error %d (%s)!!1' % (e.code, e.name),
+    title='Error %d (%s)!!1' % (code, error_name),
     html_class='error-page',
     error=e,
-  ), e.code
+  ), code
 
 
 if config.PRODUCTION:


### PR DESCRIPTION
In some cases (where Exception objects do not have a code or description), we could create a KeyError when trying to report the error. This PR aims to fix that issue.