### PR TITLE
Re-adding LinkedIn OAuth2 support

### DIFF
--- a/main/auth/__init__.py
+++ b/main/auth/__init__.py
@@ -6,5 +6,6 @@ from .facebook import *
 from .github import *
 from .gae import *
 from .google import *
+from .linkedin import *
 from .microsoft import *
 from .twitter import *

--- a/main/auth/auth.py
+++ b/main/auth/auth.py
@@ -306,6 +306,7 @@ def urls_for_oauth(next_url):
     'github_signin_url': url_for_signin('github', next_url),
     'google_signin_url': url_for_signin('google', next_url),
     'gae_signin_url': url_for_signin('gae', next_url),
+    'linkedin_signin_url': url_for_signin('linkedin', next_url),
     'microsoft_signin_url': url_for_signin('microsoft', next_url),
     'twitter_signin_url': url_for_signin('twitter', next_url),
   }
@@ -348,7 +349,7 @@ def signin_oauth(oauth_app, scheme=None):
       '%s_authorized' % oauth_app.name, _external=True, _scheme=scheme
     )
     if oauth_app.name == 'microsoft':
-        redirect_uri = redirect_uri.replace('127.0.0.1', 'localhost')
+      redirect_uri = redirect_uri.replace('127.0.0.1', 'localhost')
     return oauth_app.authorize_redirect(redirect_uri)
   except OAuthError:
     flask.flash(

--- a/main/auth/linkedin.py
+++ b/main/auth/linkedin.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import flask
+import json
 
 import auth
 import config
@@ -11,40 +12,36 @@ import util
 
 from main import app
 
+
 linkedin_config = dict(
   access_token_method='POST',
   access_token_url='https://www.linkedin.com/uas/oauth2/accessToken',
-  api_base_url='https://api.linkedin.com/v1/',
+  api_base_url='https://api.linkedin.com/v2/',
   authorize_url='https://www.linkedin.com/uas/oauth2/authorization',
   client_id=config.CONFIG_DB.linkedin_api_key,
   client_secret=config.CONFIG_DB.linkedin_secret_key,
-  request_token_params={
-    'scope': 'r_basicprofile r_emailaddress',
+  client_kwargs={
+    'scope': 'r_liteprofile r_emailaddress',
     'state': util.uuid(),
+    'token_endpoint_auth_method': 'client_secret_post',
   },
-  save_request_token=auth.save_oauth1_request_token,
-  fetch_request_token=auth.fetch_oauth1_request_token,
 )
+
 
 linkedin = auth.create_oauth_app(linkedin_config, 'linkedin')
 
 
-def change_linkedin_query(uri, headers, body):
-  headers['x-li-format'] = 'json'
-  return uri, headers, body
-
-
-linkedin.pre_request = change_linkedin_query
-
-
 @app.route('/api/auth/callback/linkedin/')
 def linkedin_authorized():
+  err = flask.request.args.get('error')
+  if err in ['user_cancelled_login', 'user_cancelled_authorize']:
+    flask.flash('You denied the request to sign in.')
+    return flask.redirect(util.get_next_url())
   id_token = linkedin.authorize_access_token()
   if id_token is None:
     flask.flash('You denied the request to sign in.')
     return flask.redirect(util.get_next_url())
-
-  me = linkedin.get('people/~:(id,first-name,last-name,email-address)')
+  me = linkedin.get('me?projection=(id,firstName,lastName)')
   user_db = retrieve_user_from_linkedin(me.json())
   return auth.signin_user_db(user_db)
 
@@ -54,14 +51,51 @@ def signin_linkedin():
   return auth.signin_oauth(linkedin)
 
 
+def dict_gets(dct, k, default=None, sep='|'):
+  # lookup by walking path in object
+  keys = k.split(sep)
+  data = dct
+  try:
+    for key in keys:
+      data = data[key]
+  except:
+    data = default
+  return data
+
+
+def get_localized_value(data, key):
+  locale = '{}_{}'.format(
+    dict_gets(data, k='{}|preferredLocale|language'.format(key), default='en'),
+    dict_gets(data, k='{}|preferredLocale|country'.format(key), default='US'),
+  )
+  return dict_gets(data, k='{}|localized|{}'.format(key, locale), default='')
+
+
+def get_email_address(data):
+  email = ''
+  emails = dict_gets(data, k='elements', default=[])
+  if isinstance(emails, list) and len(emails):
+    for e in emails:
+      email = dict_gets(e, k='handle~|emailAddress', default='')
+      if email:
+        break
+  elif isinstance(emails, dict):
+    # according to the API documentation this could be returned
+    email = dict_gets(emails, k='handle~|emailAddress', default='')
+  return email
+
+
 def retrieve_user_from_linkedin(response):
   auth_id = 'linkedin_%s' % response['id']
   user_db = model.User.get_by('auth_ids', auth_id)
   if user_db:
     return user_db
-
-  name = response[formatedName]
-  email = response.get('emailAddress', '')
+  name = ' '.join([
+    get_localized_value(response, 'firstName'),
+    get_localized_value(response, 'lastName'),
+  ]).strip()
+  email_response = linkedin.get('emailAddress?q=members&projection=(elements*(handle~))')
+  email = get_email_address(email_response.json())
   return auth.create_user_db(
     auth_id=auth_id,
     name=name,

--- a/main/control/admin.py
+++ b/main/control/admin.py
@@ -99,6 +99,8 @@ class AuthUpdateForm(flask_wtf.FlaskForm):
   github_client_secret = wtforms.StringField(model.Config.github_client_secret._verbose_name, filters=[util.strip_filter])
   google_client_id = wtforms.StringField(model.Config.google_client_id._verbose_name, filters=[util.strip_filter])
   google_client_secret = wtforms.StringField(model.Config.google_client_secret._verbose_name, filters=[util.strip_filter])
+  linkedin_api_key = wtforms.StringField(model.Config.linkedin_api_key._verbose_name, filters=[util.strip_filter])
+  linkedin_secret_key = wtforms.StringField(model.Config.linkedin_secret_key._verbose_name, filters=[util.strip_filter])
   microsoft_client_id = wtforms.StringField(model.Config.microsoft_client_id._verbose_name, filters=[util.strip_filter])
   microsoft_client_secret = wtforms.StringField(model.Config.microsoft_client_secret._verbose_name, filters=[util.strip_filter])
   twitter_consumer_key = wtforms.StringField(model.Config.twitter_consumer_key._verbose_name, filters=[util.strip_filter])

--- a/main/model/config_auth.py
+++ b/main/model/config_auth.py
@@ -17,6 +17,8 @@ class ConfigAuth(object):
   github_client_secret = ndb.StringProperty(default='', verbose_name='Client Secret')
   google_client_id = ndb.StringProperty(default='', verbose_name='Client ID')
   google_client_secret = ndb.StringProperty(default='', verbose_name='Client Secret')
+  linkedin_api_key = ndb.StringProperty(default='', verbose_name='API Key')
+  linkedin_secret_key = ndb.StringProperty(default='', verbose_name='Secret Key')
   microsoft_client_id = ndb.StringProperty(default='', verbose_name='Client ID')
   microsoft_client_secret = ndb.StringProperty(default='', verbose_name='Client Secret')
   twitter_consumer_key = ndb.StringProperty(default='', verbose_name='Consumer Key')
@@ -39,6 +41,10 @@ class ConfigAuth(object):
     return bool(self.github_client_id and self.github_client_secret)
 
   @property
+  def has_linkedin(self):
+    return bool(self.linkedin_api_key and self.linkedin_secret_key)
+
+  @property
   def has_microsoft(self):
     return bool(self.microsoft_client_id and self.microsoft_client_secret)
 
@@ -56,6 +62,8 @@ class ConfigAuth(object):
     'github_client_secret': fields.String,
     'google_client_id': fields.String,
     'google_client_secret': fields.String,
+    'linkedin_api_key': fields.String,
+    'linkedin_secret_key': fields.String,
     'microsoft_client_id': fields.String,
     'microsoft_client_secret': fields.String,
     'twitter_consumer_key': fields.String,

--- a/main/static/src/style/signin.less
+++ b/main/static/src/style/signin.less
@@ -110,6 +110,9 @@
 .btn-google {
   .btn-social(#dd4b39);
 }
+.btn-linkedin {
+  .btn-social(#007bb6);
+}
 .btn-microsoft {
   .btn-social(#2672ec);
 }

--- a/main/templates/admin/admin_auth.html
+++ b/main/templates/admin/admin_auth.html
@@ -11,6 +11,7 @@
           # include 'admin/bit/facebook_oauth.html'
           # include 'admin/bit/github_oauth.html'
           # include 'admin/bit/google_oauth.html'
+          # include 'admin/bit/linkedin_oauth.html'
           # include 'admin/bit/microsoft_oauth.html'
           # include 'admin/bit/twitter_oauth.html'
         </div>

--- a/main/templates/admin/bit/linkedin_oauth.html
+++ b/main/templates/admin/bit/linkedin_oauth.html
@@ -1,0 +1,10 @@
+{{
+  forms.panel_fields(
+    'LinkedIn',
+    (form.linkedin_api_key, form.linkedin_secret_key),
+    '''
+      OAuth 2.0 Redirect URL for <a href="https://www.linkedin.com/secure/developer" target="_blank">LinkedIn Application</a>:
+      <em>%s</em>
+    ''' % url_for('linkedin_authorized', _external=True)
+  )
+}}

--- a/main/templates/auth/auth.html
+++ b/main/templates/auth/auth.html
@@ -26,6 +26,7 @@
           {{utils.signin_button('Bitbucket', 'btn-bitbucket', 'fa-bitbucket', bitbucket_signin_url, is_icon) if config.CONFIG_DB.has_bitbucket}}
           {{utils.signin_button('GitHub', 'btn-github', 'fa-github', github_signin_url, is_icon) if config.CONFIG_DB.has_github}}
           {{utils.signin_button('Google', 'btn-google', 'fa-google', google_signin_url, is_icon) if config.CONFIG_DB.has_google}}
+          {{utils.signin_button('LinkedIn', 'btn-linkedin', 'fa-linkedin', linkedin_signin_url, is_icon) if config.CONFIG_DB.has_linkedin}}
           {{utils.signin_button('Microsoft', 'btn-microsoft', 'fa-windows', microsoft_signin_url, is_icon) if config.CONFIG_DB.has_microsoft}}
         </div>
         <hr>

--- a/main/templates/macro/utils.html
+++ b/main/templates/macro/utils.html
@@ -77,6 +77,8 @@
     <span class="fa fa-fw fa-google" title="Google"></span>
   # elif auth_id.startswith('federated')
     <span class="fa fa-fw fa-google" title="Google App Engine"></span>
+  # elif auth_id.startswith('linkedin')
+    <span class="fa fa-fw fa-linkedin" title="LinkedIn"></span>
   # elif auth_id.startswith('microsoft')
     <span class="fa fa-fw fa-windows" title="Microsoft"></span>
   # elif auth_id.startswith('twitter')


### PR DESCRIPTION
This re-adds support for LinkedIn OAuth2 for login/signup; which was a capability lost when `gae-init` was refactored to use Authlib.

Note that this uses a compliance fix, based on information gathered from https://github.com/authlib/loginpass/blob/master/loginpass/linkedin.py

Which turned out to be more helpful than https://docs.authlib.org/en/latest/client/oauth2.html?highlight=linkedin#compliance-fix-for-non-standard that I also tried to follow/add to this.

I'm no OAuth2 wizard, so I just struggled until it worked for me... mixing and matching code snippets and trying out different combinations.

After I got it working, I also tried to cancel both at the login or at the approve access rights steps of LinkedIn and added handling for these two cancellation points as well.