### PR TITLE
Handle cancel of access rights in Microsoft OAuth2 sign-up

### DIFF
--- a/main/auth/microsoft.py
+++ b/main/auth/microsoft.py
@@ -26,6 +26,10 @@ microsoft = auth.create_oauth_app(microsoft_config, 'microsoft')
 
 @app.route('/api/auth/callback/microsoft/')
 def microsoft_authorized():
+  err = flask.request.args.get('error')
+  if err in ['access_denied']:
+    flask.flash('You denied the request to sign in.')
+    return flask.redirect(util.get_next_url())
   id_token = microsoft.authorize_access_token()
   if id_token is None:
     flask.flash('You denied the request to sign in.')


### PR DESCRIPTION
Handle cancellation of allowing access rights in Microsoft OAuth2 sign-up process. While others (such as LinkedIn) may allow even to cancel the login (during the new user sign-up process), I couldn't find that option in the process flow. It is however the reason why this PR has a `in` test rather than a `==` test; to make it similar to the LinkedIn PR in #1451 - and I wouldn't be surprised if Microsoft would add it in the future.