### PR TITLE
Fixed whitespace and imports

### DIFF
--- a/main/auth/auth.py
+++ b/main/auth/auth.py
@@ -2,16 +2,16 @@
 
 from __future__ import absolute_import
 
-import functools
-import re
-
-from authlib.integrations.flask_client import OAuth, OAuthError
-from google.appengine.ext import ndb
 import flask
 import flask_login
 import flask_wtf
+import functools
+import re
 import unidecode
 import wtforms
+
+from authlib.integrations.flask_client import OAuth, OAuthError
+from google.appengine.ext import ndb
 
 import cache
 import config
@@ -335,7 +335,7 @@ def save_request_params():
 def save_oauth1_request_token(token):
   flask.session['oauth_token'] = token
 
-    
+
 def fetch_oauth1_request_token():
   return flask.session['oauth_token']
 
@@ -348,7 +348,7 @@ def signin_oauth(oauth_app, scheme=None):
       '%s_authorized' % oauth_app.name, _external=True, _scheme=scheme
     )
     if oauth_app.name == 'microsoft':
-        redirect_uri = redirect_uri.replace('127.0.0.1', 'localhost')
+      redirect_uri = redirect_uri.replace('127.0.0.1', 'localhost')
     return oauth_app.authorize_redirect(redirect_uri)
   except OAuthError:
     flask.flash(


### PR DESCRIPTION
Removed extra spaces before `def`, fixed indentation after `if`, and re-ordered imports.

Changed import order to what is more commonly used in `gae-init`: first full `import` imports from common libs, followed by `from` imports from common libs, then full `import` from project, and finally `from` imports from project.

Note that this PR replaces #1476 as I couldn't get it squashed properly, so resubmitting instead.