### PR TITLE
Update the Python requirements

### DIFF
--- a/main/requirements.txt
+++ b/main/requirements.txt
@@ -1,14 +1,14 @@
 authlib==0.14.3  # 0.15 -- 0.15.3 give errors on dev_server, as they import non-pure python module.
 blinker==1.4
 flask-login==0.5.0
-flask-restful==0.3.8
+flask-restful==0.3.9
 flask-wtf==0.14.3
-flask==1.1.2
+flask==1.1.4
 googleapis_common_protos==1.52.0
 jinja2==2.11.3
 pycrypto==2.6.1
 requests_toolbelt==0.9.1
-simplejson==3.17.2
+simplejson==3.17.3
 unidecode==1.2.0
 webargs==5.5.3
 werkzeug==1.0.1


### PR DESCRIPTION
Update the Python requirements flask to 1.1.4, flask-restful to 0.3.9, and simplejson to 3.17.3

The update of flask to 1.1.4 will runtime wise (check via /admin/test/) also update some other dependencies, including certifi to 2021.05.30 and requests to 2.26.0; it also appears that jinja2 to 2.11.3 depends on this.

Note that I had to "gcloud components update" for all the changes (especially flask) to apply when deploying to GAE, where my gcloud components was pretty old before... so YMMV