### PR TITLE
Improved cleanup in development

### DIFF
--- a/gulp/paths.js
+++ b/gulp/paths.js
@@ -19,8 +19,8 @@
   paths.dep.py_guard = `${paths.temp.root}/pip.guard`;
 
   paths.py.lib = `${paths.main}/lib`;
-  paths.py.lib_file = `${paths.py.lib}.zip`;
-
+  paths.py.libdev = `${paths.main}/libdev`;
+  
   paths.static.root = `${paths.main}/static`;
   paths.static.dev = `${paths.static.root}/dev`;
   paths.static.ext = `${paths.static.root}/ext`;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -280,7 +280,7 @@ gulp.task('clean:min', () => {
 
 gulp.task('clean:venv', () => {
   del(paths.py.lib);
-  del(paths.py.lib_file);
+  del(paths.py.libdev);
   del(paths.dep.py);
   return del(paths.dep.py_guard);
 });
@@ -364,8 +364,7 @@ gulp.task('watch', () => {
 /*** Build ***/
 
 /**
-  Build project to prepare it for a deployment. Minify CSS & JS files
-  and pack Python dependencies into #{paths.py.lib_file}.
+  Build project to prepare it for a deployment (minify CSS & JS files).
   @task {build}
   */
 gulp.task(

--- a/main/app.yaml
+++ b/main/app.yaml
@@ -69,7 +69,6 @@ skip_files:
   - ^(.*/)?index\.yaml
   - ^(.*/)?index\.yml
   - ^lib/.*-info/
-  - ^lib-dev/
   - ^requirements-dev.txt
   - ^static/dev/.*
   - ^static/ext/.*\.coffee

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gulp-util": "3.0.8",
     "gulp-watch": "5.0.1",
     "gulp-yarn": "3.0.0",
-    "gulp-zip": "5.1.0",
     "husky": "6.0.0",
     "less": "3.13.1",
     "lint-staged": "11.0.0",


### PR DESCRIPTION
Improved cleanup in development, so that the `main/libdev` folder is removed on a `gulp reset` (within the `clean:venv` task).

Also removed references and tools for the now obsolete `lib.zip` approach (which #1595 addressed), including dropping of the `gulp-zip` in the `devDependencies` of `package.json` as this is no longer needed.

In the `app.yaml` there used to be an attempt to avoid the `main/libdev` folder from being deployed into GAE. However, due to a typo in `app.yaml` (using `lib-dev` in the RegEx) this actually never worked anyway. When I tried to remove the typo dash, that caused an issue when trying to run the local development server with `gulp`. Perhaps there is a way to have the libdev folder elsewhere in the local development environment, but for now it removes something that didn't work anyway (and thus the end result is the same: the `main/libdev` is deployed, as it already was).